### PR TITLE
Fix GUI not updating

### DIFF
--- a/src/main/java/seedu/address/logic/CommandResult.java
+++ b/src/main/java/seedu/address/logic/CommandResult.java
@@ -15,6 +15,7 @@ public class CommandResult {
     public enum CommandType {
         HELP,
         EXIT,
+        GENERAL,
         LIST_C,
         LIST_P,
         LIST_I,

--- a/src/main/java/seedu/address/logic/CommandResult.java
+++ b/src/main/java/seedu/address/logic/CommandResult.java
@@ -4,124 +4,43 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
-import seedu.address.logic.candidate.FindCandidateCommand;
-import seedu.address.logic.candidate.ListCandidateCommand;
-import seedu.address.logic.interview.ListInterviewCommand;
-import seedu.address.logic.position.FindPositionCommand;
-import seedu.address.logic.position.ListPositionCommand;
-
 /**
  * Represents the result of a command execution.
  */
 public class CommandResult {
 
     private final String feedbackToUser;
+    private final CommandType commandType;
 
-    /**
-     * Help information should be shown to the user.
-     */
-    private final boolean isShowHelp;
-
-    /**
-     * The application should exit.
-     */
-    private final boolean isExit;
-
-    /**
-     * The application should display candidate list.
-     */
-    private final boolean isListC;
-
-    /**
-     * The application should display position list.
-     */
-    private final boolean isListP;
-
-    /**
-     * The application should display interview list.
-     */
-    private final boolean isListI;
-
-    /**
-     * The application should display find candidate list.
-     */
-    private final boolean isFindC;
-
-    /**
-     * The application should display position list.
-     */
-    private final boolean isFindP;
-
-    /**
-     * The application should display interview list.
-     */
-    private final boolean isFindI;
-
-    /**
-     * Constructs a {@code CommandResult} with the specified fields.
-     */
-    public CommandResult(String feedbackToUser,
-                         boolean isShowHelp, boolean isExit, boolean isListC, boolean isListP, boolean isListI,
-                        boolean isFindC, boolean isFindP, boolean isFindI) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.isShowHelp = isShowHelp;
-        this.isExit = isExit;
-        this.isListC = isListC;
-        this.isListP = isListP;
-        this.isListI = isListI;
-        this.isFindC = isFindC;
-        this.isFindP = isFindP;
-        this.isFindI = isFindI;
+    public enum CommandType {
+        HELP,
+        EXIT,
+        LIST_C,
+        LIST_P,
+        LIST_I,
+        FIND_C,
+        FIND_P,
+        FIND_I,
+        CANDIDATE,
+        POSITION,
+        INTERVIEW,
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
      * and other fields set to their default value.
      */
-    public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false,
-                feedbackToUser.equals(ListCandidateCommand.MESSAGE_SUCCESS),
-                feedbackToUser.equals(ListPositionCommand.MESSAGE_SUCCESS),
-                feedbackToUser.equals(ListInterviewCommand.MESSAGE_SUCCESS),
-                feedbackToUser.equals(FindCandidateCommand.MESSAGE_SUCCESS),
-                feedbackToUser.equals(FindPositionCommand.MESSAGE_SUCCESS),
-                false);
+    public CommandResult(String feedbackToUser, CommandType commandType) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.commandType = commandType;
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
     }
 
-    public boolean isShowHelp() {
-        return isShowHelp;
-    }
-
-    public boolean isExit() {
-        return isExit;
-    }
-
-    public boolean isListC() {
-        return isListC;
-    }
-
-    public boolean isListP() {
-        return isListP;
-    }
-
-    public boolean isListI() {
-        return isListI;
-    }
-
-    public boolean isFindC() {
-        return isFindC;
-    }
-
-    public boolean isFindP() {
-        return isFindP;
-    }
-
-    public boolean isFindI() {
-        return isFindI;
+    public CommandType getCommandType() {
+        return commandType;
     }
 
     @Override
@@ -137,19 +56,12 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && isShowHelp == otherCommandResult.isShowHelp()
-                && isExit == otherCommandResult.isExit()
-                && isListC == otherCommandResult.isListC()
-                && isListP == otherCommandResult.isListP()
-                && isListI == otherCommandResult.isListI()
-                && isFindC == otherCommandResult.isFindC()
-                && isFindP == otherCommandResult.isFindP()
-                && isFindI == otherCommandResult.isFindI();
+                && commandType.equals(otherCommandResult.commandType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, isShowHelp, isExit, isListC, isListP, isListI, isFindC, isFindP, isFindI);
+        return Objects.hash(feedbackToUser, commandType);
     }
 
 }

--- a/src/main/java/seedu/address/logic/candidate/AddCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/AddCandidateCommand.java
@@ -76,7 +76,7 @@ public class AddCandidateCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandResult.CommandType.CANDIDATE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/candidate/DeleteCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/DeleteCandidateCommand.java
@@ -44,7 +44,8 @@ public class DeleteCandidateCommand extends Command {
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
         model.deletePersonFromInterview(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete),
+                CommandResult.CommandType.CANDIDATE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,7 +89,6 @@ public class EditCandidateCommand extends Command {
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
-
         Set<Position> newPositions = editedPerson.getPositions();
         for (Position p : newPositions) {
             if (!model.hasPosition(p)) {
@@ -100,16 +98,13 @@ public class EditCandidateCommand extends Command {
                 throw new CommandException("Position " + p.getTitle().fullTitle + " is closed");
             }
         }
-
         //Remove the old person and add the new one
         Set<Interview> interviews = personToEdit.getInterviews();
         for (Interview i : interviews) {
             i.removeCandidate(personToEdit);
             i.addCandidate(editedPerson);
         }
-
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson),
                 CommandResult.CommandType.CANDIDATE);
     }

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -111,7 +111,7 @@ public class EditCandidateCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson),
-                false, false, true, false, false, false, false, false);
+                CommandResult.CommandType.CANDIDATE);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -109,7 +109,6 @@ public class EditCandidateCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson),
                 CommandResult.CommandType.CANDIDATE);
     }

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -108,6 +109,7 @@ public class EditCandidateCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson),
                 CommandResult.CommandType.CANDIDATE);
     }

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -8,12 +8,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-<<<<<<< HEAD
-=======
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
 import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
->>>>>>> master
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -107,12 +103,8 @@ public class EditCandidateCommand extends Command {
             }
             positionReferences.add(model.getPositionReference(p));
         }
-<<<<<<< HEAD
-=======
-
         editedPerson.setPositions(positionReferences);
 
->>>>>>> master
         //Remove the old person and add the new one
         Set<Interview> interviews = personToEdit.getInterviews();
         for (Interview i : interviews) {

--- a/src/main/java/seedu/address/logic/candidate/FindCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/FindCandidateCommand.java
@@ -48,7 +48,7 @@ public class FindCandidateCommand extends Command {
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
-                false, false, false, false, false, true, false, false);
+                CommandResult.CommandType.FIND_C);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/candidate/ListCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/ListCandidateCommand.java
@@ -21,6 +21,6 @@ public class ListCandidateCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, false, false, true, false, false, false, false, false);
+        return new CommandResult(MESSAGE_SUCCESS, CommandResult.CommandType.LIST_C);
     }
 }

--- a/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.candidate;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -60,7 +59,6 @@ public class RemarkCandidateCommand extends Command {
                 personToEdit.getPositions());
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(generateSuccessMessage(editedPerson), CommandResult.CommandType.CANDIDATE);
     }

--- a/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
@@ -62,7 +62,7 @@ public class RemarkCandidateCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(generateSuccessMessage(editedPerson));
+        return new CommandResult(generateSuccessMessage(editedPerson), CommandResult.CommandType.CANDIDATE);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.candidate;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -59,6 +60,7 @@ public class RemarkCandidateCommand extends Command {
                 personToEdit.getPositions());
 
         model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(generateSuccessMessage(editedPerson), CommandResult.CommandType.CANDIDATE);
     }

--- a/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
@@ -60,7 +60,6 @@ public class RemarkCandidateCommand extends Command {
                 personToEdit.getPositions());
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(generateSuccessMessage(editedPerson), CommandResult.CommandType.CANDIDATE);
     }

--- a/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/RemarkCandidateCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.candidate;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/general/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/general/ClearCommand.java
@@ -20,6 +20,6 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setHrManager(new HrManager());
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, CommandResult.CommandType.GENERAL);
     }
 }

--- a/src/main/java/seedu/address/logic/general/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/general/ExitCommand.java
@@ -15,7 +15,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false, false, false, false, false);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandResult.CommandType.EXIT);
     }
 
 }

--- a/src/main/java/seedu/address/logic/general/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/general/HelpCommand.java
@@ -18,6 +18,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, false, false, false, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.CommandType.HELP);
     }
 }

--- a/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
@@ -76,12 +76,11 @@ public class AddInterviewCommand extends Command {
         if (model.isPositionClosed(position)) {
             throw new CommandException(String.format(MESSAGE_POSITION_CLOSED, position.getTitle()));
         }
-        //loads candidates from set of index
+
         Set<Person> candidates = new HashSet<>();
         for (Index index : indexes) {
             if (index.getZeroBased() < lastShownPersonList.size()) {
                 Person person = lastShownPersonList.get(index.getZeroBased());
-                //checks if person applied for position
                 if (!person.appliedForPosition(position)) {
                     throw new CommandException(String.format(MESSAGE_CANDIDATE_DID_NOT_APPLY,
                             person.getName(), position));
@@ -104,7 +103,6 @@ public class AddInterviewCommand extends Command {
         }
 
         model.addInterview(toAdd);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getDisplayString()),
                 CommandResult.CommandType.INTERVIEW);
     }

--- a/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
@@ -105,7 +105,8 @@ public class AddInterviewCommand extends Command {
 
         model.addInterview(toAdd);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getDisplayString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getDisplayString()),
+                CommandResult.CommandType.INTERVIEW);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/interview/AssignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AssignInterviewCommand.java
@@ -101,8 +101,7 @@ public class AssignInterviewCommand extends Command {
         model.setInterview(interview, assignedInterview);
 
         result = new CommandResult(String.format(MESSAGE_SUCCESS, interview.getDisplayStringWithoutNames(),
-                candidatesAdded), false, false, true, false, false,
-                false, false, false);
+                candidatesAdded), CommandResult.CommandType.INTERVIEW);
 
         model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
         return result;

--- a/src/main/java/seedu/address/logic/interview/AssignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AssignInterviewCommand.java
@@ -74,9 +74,6 @@ public class AssignInterviewCommand extends Command {
         StringBuilder candidatesAdded = new StringBuilder();
         candidatesAdded.append("\n");
 
-        EditCandidateCommand.EditPersonDescriptor personDescriptor = new EditCandidateCommand.EditPersonDescriptor();
-        personDescriptor.setInterviews(new HashSet<>(List.of(assignedInterview)));
-
         int count = 1;
         for (Index candidateIndex : candidateIndexes) {
             if (candidateIndex.getZeroBased() >= lastShownCandidateList.size()) {
@@ -90,9 +87,7 @@ public class AssignInterviewCommand extends Command {
                         candidateIndex.getOneBased(), candidate.getName(), interview.getPositionTitle()));
             }
             newCandidates.add(candidate);
-            Person editedPerson = EditCandidateCommand.createEditedPerson(candidate, personDescriptor);
-            model.setPerson(candidate, editedPerson);
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            candidate.addInterview(assignedInterview);
 
             candidatesAdded.append(count + ". " + candidate.getName() + "\n");
             count++;
@@ -103,7 +98,6 @@ public class AssignInterviewCommand extends Command {
         result = new CommandResult(String.format(MESSAGE_SUCCESS, interview.getDisplayStringWithoutNames(),
                 candidatesAdded), CommandResult.CommandType.INTERVIEW);
 
-        model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
         return result;
     }
 

--- a/src/main/java/seedu/address/logic/interview/AssignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AssignInterviewCommand.java
@@ -3,10 +3,7 @@ package seedu.address.logic.interview;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CANDIDATE_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_INDEX;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -14,7 +11,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Command;
 import seedu.address.logic.CommandResult;
-import seedu.address.logic.candidate.EditCandidateCommand;
 import seedu.address.logic.candidate.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.interview.Interview;

--- a/src/main/java/seedu/address/logic/interview/DeleteInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/DeleteInterviewCommand.java
@@ -43,7 +43,8 @@ public class DeleteInterviewCommand extends Command {
         model.deleteInterviewFromPerson(interviewToDelete);
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_DELETE_INTERVIEW_SUCCESS, interviewToDelete.getDisplayString()));
+        return new CommandResult(String.format(MESSAGE_DELETE_INTERVIEW_SUCCESS, interviewToDelete.getDisplayString()),
+                CommandResult.CommandType.INTERVIEW);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/interview/DeleteInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/DeleteInterviewCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.interview;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/interview/DeleteInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/DeleteInterviewCommand.java
@@ -42,7 +42,6 @@ public class DeleteInterviewCommand extends Command {
         model.deleteInterview(interviewToDelete);
         model.deleteInterviewFromPerson(interviewToDelete);
 
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_INTERVIEW_SUCCESS, interviewToDelete.getDisplayString()),
                 CommandResult.CommandType.INTERVIEW);
     }

--- a/src/main/java/seedu/address/logic/interview/EditInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/EditInterviewCommand.java
@@ -136,7 +136,7 @@ public class EditInterviewCommand extends Command {
         }
 
         return new CommandResult(String.format(MESSAGE_EDIT_INTERVIEW_SUCCESS, editedInterview.getDisplayString()),
-                false, false, false, false, true, false, false, false);
+              CommandResult.CommandType.INTERVIEW);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/interview/FindInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/FindInterviewCommand.java
@@ -47,7 +47,7 @@ public class FindInterviewCommand extends Command {
         model.updateFilteredInterviewList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_INTERVIEW_LISTED_OVERVIEW, model.getFilteredInterviewList().size()),
-            false, false, false, false, false, false, false, true);
+            CommandResult.CommandType.FIND_I);
 
     }
 

--- a/src/main/java/seedu/address/logic/interview/ListInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/ListInterviewCommand.java
@@ -19,6 +19,6 @@ public class ListInterviewCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
-        return new CommandResult(MESSAGE_SUCCESS, false, false, false, false, true, false, false, false);
+        return new CommandResult(MESSAGE_SUCCESS, CommandResult.CommandType.LIST_I);
     }
 }

--- a/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
@@ -113,8 +113,6 @@ public class UnassignInterviewCommand extends Command {
                     removedPersons), CommandResult.CommandType.INTERVIEW);
         }
 
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
         return result;
     }
 

--- a/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
@@ -91,8 +91,7 @@ public class UnassignInterviewCommand extends Command {
             model.deleteInterviewFromPerson(interview);
             result = new CommandResult(String.format(MESSAGE_ALL_CANDIDATES_REMOVED,
                     interview.getDisplayStringWithoutNames()),
-                    false, false, true, false, false, false, false,
-                    false);
+                    CommandResult.CommandType.INTERVIEW);
         } else {
             int count = 1;
             for (Index candidateIndex : candidateIndexes) {
@@ -111,8 +110,7 @@ public class UnassignInterviewCommand extends Command {
                 count++;
             }
             result = new CommandResult(String.format(MESSAGE_SUCCESS, interview.getDisplayStringWithoutNames(),
-                    removedPersons), false, false, true, false, false,
-                    false, false, false);
+                    removedPersons), CommandResult.CommandType.INTERVIEW);
         }
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
@@ -3,8 +3,6 @@ package seedu.address.logic.interview;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CANDIDATE_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_INDEX;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/position/AddPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/AddPositionCommand.java
@@ -41,7 +41,7 @@ public class AddPositionCommand extends Command {
         }
 
         model.addPosition(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandResult.CommandType.POSITION);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/DeletePositionCommand.java
@@ -43,7 +43,6 @@ public class DeletePositionCommand extends Command {
         model.deletePositionFromPerson(positionToDelete);
         model.deletePosition(positionToDelete);
 
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_POSITION_SUCCESS, positionToDelete),
                                 CommandResult.CommandType.POSITION);
     }

--- a/src/main/java/seedu/address/logic/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/DeletePositionCommand.java
@@ -44,7 +44,8 @@ public class DeletePositionCommand extends Command {
         model.deletePosition(positionToDelete);
 
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_DELETE_POSITION_SUCCESS, positionToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_POSITION_SUCCESS, positionToDelete),
+                                CommandResult.CommandType.POSITION);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/DeletePositionCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.position;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.position;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POSITIONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -70,6 +71,7 @@ public class EditPositionCommand extends Command {
         }
 
         model.setPosition(positionToEdit, editedPosition);
+        model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
 
         // Save updated position in the candidates.json file. //TODO
         for (Person person : lastShownPersonList) {

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.position;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POSITIONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -71,7 +70,6 @@ public class EditPositionCommand extends Command {
         }
 
         model.setPosition(positionToEdit, editedPosition);
-        model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
 
         // Save updated position in the candidates.json file. //TODO
         for (Person person : lastShownPersonList) {

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -101,7 +101,7 @@ public class EditPositionCommand extends Command {
         }
 
         return new CommandResult(String.format(MESSAGE_EDIT_POSITION_SUCCESS, editedPosition),
-                false, false, false, true, false, false, false, false);
+                CommandResult.CommandType.POSITION);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -73,7 +73,6 @@ public class EditPositionCommand extends Command {
         }
 
         model.setPosition(positionToEdit, editedPosition);
-        model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
 
         // Save updated position in the candidates.json file. //TODO
         for (Person person : lastShownPersonList) {
@@ -87,16 +86,6 @@ public class EditPositionCommand extends Command {
                         && !editPositionDescriptor.getPositionStatus().equals(Optional.of(PositionStatus.CLOSED))) {
                     person.addPosition(editedPosition);
                 }
-
-                EditCandidateCommand.EditPersonDescriptor editPersonDescriptor =
-                        new EditCandidateCommand.EditPersonDescriptor();
-
-                editPersonDescriptor.setPositions(positions);
-
-                Person editedPerson = EditCandidateCommand.createEditedPerson(person, editPersonDescriptor);
-
-                model.setPerson(person, editedPerson);
-                model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             }
         }
 

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -3,8 +3,6 @@ package seedu.address.logic.position;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POSITIONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +13,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.Command;
 import seedu.address.logic.CommandResult;
-import seedu.address.logic.candidate.EditCandidateCommand;
 import seedu.address.logic.candidate.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;

--- a/src/main/java/seedu/address/logic/position/FindPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/FindPositionCommand.java
@@ -42,7 +42,7 @@ public class FindPositionCommand extends Command {
         model.updateFilteredPositionList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_POSITIONS_LISTED_OVERVIEW, model.getFilteredPositionList().size()),
-            false, false, false, false, false, false, true, false);
+                                CommandResult.CommandType.FIND_P);
 
     }
 

--- a/src/main/java/seedu/address/logic/position/ListPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/ListPositionCommand.java
@@ -21,6 +21,6 @@ public class ListPositionCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
-        return new CommandResult(MESSAGE_SUCCESS, false, false, false, true, false, false, false, false);
+        return new CommandResult(MESSAGE_SUCCESS, CommandResult.CommandType.LIST_P);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -192,7 +192,7 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
-    private void handleListC(CommandResult commandResult) {
+    private void handleListC() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
@@ -202,7 +202,7 @@ public class MainWindow extends UiPart<Stage> {
         personListLabel.setText("Candidates");
     }
 
-    private void handleListP(CommandResult commandResult) {
+    private void handleListP() {
         positionListPanel = new PositionListPanel(logic.getFilteredPositionList());
         positionListPanelPlaceholder.getChildren().add(positionListPanel.getRoot());
 
@@ -211,7 +211,7 @@ public class MainWindow extends UiPart<Stage> {
         positionListLabel.setText("Positions");
     }
 
-    private void handleListI(CommandResult commandResult) {
+    private void handleListI() {
         interviewListPanel = new InterviewListPanel(logic.getFilteredInterviewList());
         interviewListPanelPlaceholder.getChildren().add(interviewListPanel.getRoot());
 
@@ -220,7 +220,7 @@ public class MainWindow extends UiPart<Stage> {
         interviewListLabel.setText("Interviews");
     }
 
-    private void handleFindC(CommandResult commandResult) {
+    private void handleFindC() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
@@ -230,7 +230,7 @@ public class MainWindow extends UiPart<Stage> {
         personListLabel.setText("Candidates (filtered)");
     }
 
-    private void handleFindP(CommandResult commandResult) {
+    private void handleFindP() {
         positionListPanel = new PositionListPanel(logic.getFilteredPositionList());
         positionListPanelPlaceholder.getChildren().add(positionListPanel.getRoot());
 
@@ -239,13 +239,46 @@ public class MainWindow extends UiPart<Stage> {
         positionListLabel.setText("Positions (filtered)");
     }
 
-    private void handleFindI(CommandResult commandResult) {
+    private void handleFindI() {
         interviewListPanel = new InterviewListPanel(logic.getFilteredInterviewList());
         interviewListPanelPlaceholder.getChildren().add(interviewListPanel.getRoot());
 
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getHrManagerInterviewsFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
         interviewListLabel.setText("Interviews (filtered)");
+    }
+
+    private void handleEditC() { //Update person and interview lists
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        interviewListPanel = new InterviewListPanel(logic.getFilteredInterviewList());
+        interviewListPanelPlaceholder.getChildren().add(interviewListPanel.getRoot());
+
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getHrManagerInterviewsFilePath());
+        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
+    }
+
+    private void handleEditP() { //Update person and position lists
+        positionListPanel = new PositionListPanel(logic.getFilteredPositionList());
+        positionListPanelPlaceholder.getChildren().add(positionListPanel.getRoot());
+
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getHrManagerInterviewsFilePath());
+        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
+    }
+
+    private void handleEditI() { //Update person and interview lists
+        interviewListPanel = new InterviewListPanel(logic.getFilteredInterviewList());
+        interviewListPanelPlaceholder.getChildren().add(interviewListPanel.getRoot());
+
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getHrManagerInterviewsFilePath());
+        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
     }
 
     /**
@@ -259,22 +292,29 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.isShowHelp()) {
+            switch(commandResult.getCommandType()) {
+            case HELP:
                 handleHelp();
-            } else if (commandResult.isExit()) {
+            case EXIT:
                 handleExit();
-            } else if (commandResult.isListC()) {
-                handleListC(commandResult);
-            } else if (commandResult.isListP()) {
-                handleListP(commandResult);
-            } else if (commandResult.isListI()) {
-                handleListI(commandResult);
-            } else if (commandResult.isFindC()) {
-                handleFindC(commandResult);
-            } else if (commandResult.isFindP()) {
-                handleFindP(commandResult);
-            } else if (commandResult.isFindI()) {
-                handleFindI(commandResult);
+            case LIST_C:
+                handleListC();
+            case LIST_P:
+                handleListP();
+            case LIST_I:
+                handleListI();
+            case FIND_C:
+                handleFindC();
+            case FIND_P:
+                handleFindP();
+            case FIND_I:
+                handleFindI();
+            case CANDIDATE:
+                handleEditC();
+            case POSITION:
+                handleEditP();
+            case INTERVIEW:
+                handleEditI();
             }
 
             return commandResult;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -248,7 +248,7 @@ public class MainWindow extends UiPart<Stage> {
         interviewListLabel.setText("Interviews (filtered)");
     }
 
-    private void handleEditC() { //Update person and interview lists
+    private void handleC() { //Update person and interview lists
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
@@ -259,7 +259,7 @@ public class MainWindow extends UiPart<Stage> {
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
     }
 
-    private void handleEditP() { //Update person and position lists
+    private void handleP() { //Update person and position lists
         positionListPanel = new PositionListPanel(logic.getFilteredPositionList());
         positionListPanelPlaceholder.getChildren().add(positionListPanel.getRoot());
 
@@ -270,7 +270,7 @@ public class MainWindow extends UiPart<Stage> {
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
     }
 
-    private void handleEditI() { //Update person and interview lists
+    private void handleI() { //Update person and interview lists
         interviewListPanel = new InterviewListPanel(logic.getFilteredInterviewList());
         interviewListPanelPlaceholder.getChildren().add(interviewListPanel.getRoot());
 
@@ -295,26 +295,37 @@ public class MainWindow extends UiPart<Stage> {
             switch(commandResult.getCommandType()) {
             case HELP:
                 handleHelp();
+                break;
             case EXIT:
                 handleExit();
+                break;
             case LIST_C:
                 handleListC();
+                break;
             case LIST_P:
                 handleListP();
+                break;
             case LIST_I:
                 handleListI();
+                break;
             case FIND_C:
                 handleFindC();
+                break;
             case FIND_P:
                 handleFindP();
+                break;
             case FIND_I:
                 handleFindI();
+                break;
             case CANDIDATE:
-                handleEditC();
+                handleC();
+                break;
             case POSITION:
-                handleEditP();
+                handleP();
+                break;
             case INTERVIEW:
-                handleEditI();
+                handleI();
+                break;
             }
 
             return commandResult;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -326,6 +326,7 @@ public class MainWindow extends UiPart<Stage> {
             case INTERVIEW:
                 handleI();
                 break;
+            default:
             }
 
             return commandResult;

--- a/src/test/java/seedu/address/logic/candidate/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/candidate/CommandResultTest.java
@@ -12,12 +12,10 @@ import seedu.address.logic.CommandResult;
 public class CommandResultTest {
     @Test
     public void equals() {
-        CommandResult commandResult = new CommandResult("feedback");
+        CommandResult commandResult = new CommandResult("feedback", CommandResult.CommandType.GENERAL);
 
         // same values -> returns true
-        assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false,
-                false, false, false, false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", CommandResult.CommandType.GENERAL)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,34 +27,34 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(0.5f));
 
         // different feedbackToUser value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("different")));
+        assertFalse(commandResult.equals(new CommandResult("different",
+                CommandResult.CommandType.GENERAL)));
 
-        // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true,
-                false, false, false, false, false,
-                false, false)));
+        // CommandType.HELP -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.CommandType.HELP)));
 
-        // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false, false, false,
-                false, false)));
+        // CommandType.EXIT -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.CommandType.EXIT)));
     }
 
     @Test
     public void hashcode() {
-        CommandResult commandResult = new CommandResult("feedback");
+        CommandResult commandResult = new CommandResult("feedback", CommandResult.CommandType.GENERAL);
 
         // same values -> returns same hashcode
-        assertEquals(commandResult.hashCode(), new CommandResult("feedback").hashCode());
+        assertEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.CommandType.GENERAL).hashCode());
 
         // different feedbackToUser value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("different",
+                CommandResult.CommandType.GENERAL).hashCode());
 
-        // different showHelp value -> returns different hashcode
+        // CommandType.HELP -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult(
-                "feedback", true, false, false, false, false, false, false, false).hashCode());
+                "feedback", CommandResult.CommandType.HELP).hashCode());
 
-        // different exit value -> returns different hashcode
+        // CommandType.EXIT -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult(
-                "feedback", false, true, false, false, false, false, false, false).hashCode());
+                "feedback", CommandResult.CommandType.EXIT).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/candidate/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/candidate/CommandTestUtil.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -134,8 +133,6 @@ public class CommandTestUtil {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedEditCommandResult, result);
-            System.out.println(expectedModel.getFilteredPersonList());
-            System.out.println(actualModel.getFilteredPersonList());
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);

--- a/src/test/java/seedu/address/logic/candidate/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/candidate/CommandTestUtil.java
@@ -103,7 +103,17 @@ public class CommandTestUtil {
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
                                             Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.CANDIDATE);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage}.
+     */
+    public static void assertListCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.LIST_C);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 
@@ -140,7 +150,7 @@ public class CommandTestUtil {
         }
 
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, true, false, false, false, false, false);
+                CommandResult.CommandType.CANDIDATE);
         assertEditCandidateCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/candidate/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/candidate/CommandTestUtil.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,6 +134,8 @@ public class CommandTestUtil {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedEditCommandResult, result);
+            System.out.println(expectedModel.getFilteredPersonList());
+            System.out.println(actualModel.getFilteredPersonList());
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);

--- a/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
@@ -105,16 +105,17 @@ public class EditCandidateCommandTest {
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        System.out.println(editedPerson);
+        Person editedPerson = new PersonBuilder(personInFilteredList).withPhone(VALID_PHONE_BOB).build();
         EditCandidateCommand editCandidateCommand = new EditCandidateCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build());
 
         String expectedMessage = String.format(EditCandidateCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new HrManager(model.getHrManager()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(firstPerson, editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertEditCandidateCommandSuccess(editCandidateCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
@@ -107,6 +107,7 @@ public class EditCandidateCommandTest {
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
+        System.out.println(editedPerson);
         EditCandidateCommand editCandidateCommand = new EditCandidateCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 

--- a/src/test/java/seedu/address/logic/candidate/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/ExitCommandTest.java
@@ -17,7 +17,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
-                false, true, false, false, false, false, false, false);
+                CommandResult.CommandType.EXIT);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/candidate/FindCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/FindCandidateCommandTest.java
@@ -68,8 +68,7 @@ public class FindCandidateCommandTest {
 
         //have to create a CommandResult manually because assertSuccess uses single parameter constructor
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false,
-                false, true, false, false);
+                CommandResult.CommandType.FIND_C);
 
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }
@@ -85,8 +84,7 @@ public class FindCandidateCommandTest {
 
         //have to create a CommandResult manually because assertSuccess uses single parameter constructor
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false,
-                false, true, false, false);
+                CommandResult.CommandType.FIND_C);
 
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/candidate/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/HelpCommandTest.java
@@ -17,7 +17,7 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(
-                SHOWING_HELP_MESSAGE, true, false, false, false, false, false, false, false);
+                SHOWING_HELP_MESSAGE, CommandResult.CommandType.HELP);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/candidate/ListCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/ListCandidateCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.candidate;
 
-import static seedu.address.logic.candidate.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.candidate.CommandTestUtil.assertListCommandSuccess;
 import static seedu.address.logic.candidate.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalHrManager;
@@ -28,12 +28,12 @@ public class ListCandidateCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/candidate/ListCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/ListCandidateCommandTest.java
@@ -28,12 +28,14 @@ public class ListCandidateCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertListCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS,
+                expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertListCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListCandidateCommand(), model, ListCandidateCommand.MESSAGE_SUCCESS,
+                expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/candidate/RemarkCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/RemarkCandidateCommandTest.java
@@ -80,6 +80,7 @@ public class RemarkCandidateCommandTest {
 
         Model expectedModel = new ModelManager(new HrManager(model.getHrManager()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(remarkCandidateCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/general/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/general/ClearCommandTest.java
@@ -1,11 +1,10 @@
-package seedu.address.logic.candidate;
+package seedu.address.logic.general;
 
-import static seedu.address.logic.candidate.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.general.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalHrManager;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.general.ClearCommand;
 import seedu.address.model.HrManager;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -29,5 +28,4 @@ public class ClearCommandTest {
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
-
 }

--- a/src/test/java/seedu/address/logic/general/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/general/CommandTestUtil.java
@@ -1,11 +1,11 @@
 package seedu.address.logic.general;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import seedu.address.logic.Command;
 import seedu.address.logic.CommandResult;
 import seedu.address.logic.candidate.exceptions.CommandException;
 import seedu.address.model.Model;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommandTestUtil {
 

--- a/src/test/java/seedu/address/logic/general/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/general/CommandTestUtil.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.general;
+
+import seedu.address.logic.Command;
+import seedu.address.logic.CommandResult;
+import seedu.address.logic.candidate.exceptions.CommandException;
+import seedu.address.model.Model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CommandTestUtil {
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
+     * - the {@code actualModel} matches {@code expectedModel}
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
+                                            Model expectedModel) {
+        try {
+            CommandResult result = command.execute(actualModel);
+            assertEquals(expectedCommandResult, result);
+            assertEquals(expectedModel, actualModel);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage}.
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.GENERAL);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/interview/AssignInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/AssignInterviewCommandTest.java
@@ -73,6 +73,9 @@ public class AssignInterviewCommandTest {
 
         Model expectedModel = new ModelManager(new HrManager(model.getHrManager()), new UserPrefs());
         assertCommandSuccess(assignInterviewCommand, model, expectedCommandResult, expectedModel);
+
+        alice.deleteInterview(assignedInterview);
+        assignedInterview.removeCandidate(alice);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/interview/AssignInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/AssignInterviewCommandTest.java
@@ -75,7 +75,7 @@ public class AssignInterviewCommandTest {
         assertCommandSuccess(assignInterviewCommand, model, expectedCommandResult, expectedModel);
 
         alice.deleteInterview(assignedInterview);
-        assignedInterview.removeCandidate(alice);
+        assignedInterview.deleteCandidate(alice);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/interview/AssignInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/AssignInterviewCommandTest.java
@@ -69,9 +69,7 @@ public class AssignInterviewCommandTest {
         copyOfAlice.addInterview(assignedInterview);
         assignedInterview.addCandidate(copyOfAlice);
 
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
-                true, false, false, false, false,
-                false);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.INTERVIEW);
 
         Model expectedModel = new ModelManager(new HrManager(model.getHrManager()), new UserPrefs());
         assertCommandSuccess(assignInterviewCommand, model, expectedCommandResult, expectedModel);

--- a/src/test/java/seedu/address/logic/interview/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/interview/CommandTestUtil.java
@@ -114,8 +114,6 @@ public class CommandTestUtil {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
-            System.out.println(expectedModel.getFilteredPersonList());
-            System.out.println(actualModel.getFilteredPersonList());
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);

--- a/src/test/java/seedu/address/logic/interview/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/interview/CommandTestUtil.java
@@ -126,7 +126,17 @@ public class CommandTestUtil {
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
                                             Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.INTERVIEW);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage}.
+     */
+    public static void assertListCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.LIST_I);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 
@@ -163,7 +173,7 @@ public class CommandTestUtil {
         }
 
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false, true, false, false, false);
+                CommandResult.CommandType.INTERVIEW);
         assertEditInterviewCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/interview/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/interview/CommandTestUtil.java
@@ -114,6 +114,8 @@ public class CommandTestUtil {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
+            System.out.println(expectedModel.getFilteredPersonList());
+            System.out.println(actualModel.getFilteredPersonList());
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);

--- a/src/test/java/seedu/address/logic/interview/FindInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/FindInterviewCommandTest.java
@@ -73,8 +73,7 @@ public class FindInterviewCommandTest {
 
         //have to create a CommandResult manually because assertSuccess uses single parameter constructor
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false,
-                false, false, false, true);
+                CommandResult.CommandType.FIND_I);
 
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }
@@ -90,8 +89,7 @@ public class FindInterviewCommandTest {
 
         //have to create a CommandResult manually because assertSuccess uses single parameter constructor
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false,
-                false, false, false, true);
+                CommandResult.CommandType.FIND_I);
 
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/interview/ListInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/ListInterviewCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.interview;
 
-import static seedu.address.logic.interview.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.interview.CommandTestUtil.assertListCommandSuccess;
 import static seedu.address.logic.interview.CommandTestUtil.showInterviewAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_INTERVIEW;
 import static seedu.address.testutil.TypicalPersons.getTypicalHrManager;
@@ -28,12 +28,12 @@ public class ListInterviewCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showInterviewAtIndex(model, INDEX_FIRST_INTERVIEW);
-        assertCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/interview/ListInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/ListInterviewCommandTest.java
@@ -28,12 +28,14 @@ public class ListInterviewCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertListCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS,
+                expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showInterviewAtIndex(model, INDEX_FIRST_INTERVIEW);
-        assertListCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListInterviewCommand(), model, ListInterviewCommand.MESSAGE_SUCCESS,
+                expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/interview/UnassignInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/UnassignInterviewCommandTest.java
@@ -65,9 +65,7 @@ public class UnassignInterviewCommandTest {
         candidates.add(alice);
         interviewToUnassign.setCandidates(candidates);
 
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
-                true, false, false, false, false,
-                false);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.INTERVIEW);
 
         ModelManager expectedModel = new ModelManager(getTypicalHrManager(), new UserPrefs());
 
@@ -103,9 +101,7 @@ public class UnassignInterviewCommandTest {
         benson.addInterview(interviewToUnassign);
         interviewToUnassign.setCandidates(candidates);
 
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
-                true, false, false, false, false,
-                false);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.INTERVIEW);
 
         ModelManager expectedModel = new ModelManager(getTypicalHrManager(), new UserPrefs());
 

--- a/src/test/java/seedu/address/logic/position/AddPositionCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/position/AddPositionCommandIntegrationTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.position;
 
-import static seedu.address.logic.candidate.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.candidate.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.position.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.position.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalHrManager;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/seedu/address/logic/position/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/position/CommandTestUtil.java
@@ -75,9 +75,10 @@ public class CommandTestUtil {
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
                                             Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.POSITION);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
+
     private static boolean isEditPCommand(Command command) {
         String commandClassName = command.getClass().getSimpleName();
         return commandClassName.equals("EditPositionCommand");
@@ -111,8 +112,18 @@ public class CommandTestUtil {
         }
 
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, true, false, false, false, false);
+                CommandResult.CommandType.POSITION);
         assertEditPositionCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage}.
+     */
+    public static void assertListCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.LIST_P);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
@@ -197,8 +197,7 @@ public class EditPositionCommandTest {
             CommandResult result = command.execute(model);
             //because standard constructor of CommandResult does not update isListP to true
             assertEquals(result, new CommandResult(expectedMessage,
-                    false, false, false,
-                    true, false, false, false, false));
+                    CommandResult.CommandType.POSITION));
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }

--- a/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
@@ -93,6 +93,7 @@ public class EditPositionCommandTest {
 
         Model expectedModel = new ModelManager(new HrManager(model.getHrManager()), new UserPrefs());
         expectedModel.setPosition(model.getFilteredPositionList().get(0), editedPosition);
+        showPositionAtIndex(expectedModel, INDEX_FIRST_POSITION);
 
         assertEditPositionCommandSuccess(editPositionCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/position/FindPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/position/FindPositionCommandTest.java
@@ -63,9 +63,7 @@ public class FindPositionCommandTest {
         FindPositionCommand command = new FindPositionCommand(predicate);
         expectedModel.updateFilteredPositionList(predicate);
         assertEquals(Arrays.asList(ADMIN_ASSISTANT), expectedModel.getFilteredPositionList());
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false,
-                false, false, true, false);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.CommandType.FIND_P);
 
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }
@@ -80,8 +78,7 @@ public class FindPositionCommandTest {
 
         //have to create a CommandResult manually because assertSuccess uses single parameter constructor
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                false, false, false, false,
-                false, false, true, false);
+                CommandResult.CommandType.FIND_P);
 
         assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/position/ListPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/position/ListPositionCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.position;
 
-import static seedu.address.logic.position.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.position.CommandTestUtil.assertListCommandSuccess;
 import static seedu.address.logic.position.CommandTestUtil.showPositionAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_POSITION;
 import static seedu.address.testutil.TypicalPersons.getTypicalHrManager;
@@ -28,12 +28,12 @@ public class ListPositionCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListPositionCommand(), model, ListPositionCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListPositionCommand(), model, ListPositionCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPositionAtIndex(model, INDEX_FIRST_POSITION);
-        assertCommandSuccess(new ListPositionCommand(), model, ListPositionCommand.MESSAGE_SUCCESS, expectedModel);
+        assertListCommandSuccess(new ListPositionCommand(), model, ListPositionCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonSerializableHrManagerCandidatesTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableHrManagerCandidatesTest.java
@@ -28,6 +28,8 @@ public class JsonSerializableHrManagerCandidatesTest {
                 JsonSerializableHrManagerCandidates.class).get();
         HrManager addressBookFromFile = dataFromFile.toModelType();
         HrManager typicalPersonsAddressBook = TypicalPersons.getTypicalHrManagerWithOnlyTypicalPersons();
+        System.out.println("TEST" + addressBookFromFile.getPersonList());
+        System.out.println("TEST" + typicalPersonsAddressBook.getPersonList());
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 

--- a/src/test/java/seedu/address/storage/JsonSerializableHrManagerCandidatesTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableHrManagerCandidatesTest.java
@@ -28,8 +28,6 @@ public class JsonSerializableHrManagerCandidatesTest {
                 JsonSerializableHrManagerCandidates.class).get();
         HrManager addressBookFromFile = dataFromFile.toModelType();
         HrManager typicalPersonsAddressBook = TypicalPersons.getTypicalHrManagerWithOnlyTypicalPersons();
-        System.out.println("TEST" + addressBookFromFile.getPersonList());
-        System.out.println("TEST" + typicalPersonsAddressBook.getPersonList());
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 


### PR DESCRIPTION
- Updated CommandResult
    - Now has enum CommandType
    - Constructor changed to take in CommandType
    - Updated relevant test cases
- Updated MainWindow
    - Every command now updates their respective lists
        - listC, listP, listI
        - findC, findP, findI
        - CANDIDATE commands update candidate and interview lists
        - POSITION commands update candidate and positions lists
        - INTERVIEW commands update candidate and interview lists
- Fix AssignCommand
    - Update such that execute adds assignedInterview object to the candidate object
- Remove irrelevant EditDescriptor from AssignInterview and EditInterview

- Current behaviour:
    **- If find_x first, doing any command other than find_x or list_x WILL NOT RESET any lists.**

Fix #219 #217 #200