### PR TITLE
Fix position naming

### DIFF
--- a/src/main/java/seedu/address/logic/candidate/AddCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/AddCandidateCommand.java
@@ -8,7 +8,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.logic.Command;
@@ -66,15 +69,20 @@ public class AddCandidateCommand extends Command {
         }
 
         Set<Position> positions = toAdd.getPositions();
+        Set<Position> positionReferences = new HashSet<>();
         for (Position p : positions) {
             if (!model.hasPosition(p)) {
-                throw new CommandException("Position " + p.getTitle().fullTitle + " not found in HR Manager");
+                throw new CommandException(String.format(MESSAGE_POSITION_DOES_NOT_EXIST, p.getTitle()));
             }
             if (model.isPositionClosed(p)) {
-                throw new CommandException("Position " + p.getTitle().fullTitle + " is closed");
+                throw new CommandException(String.format(MESSAGE_POSITION_CLOSED,
+                        model.getPositionReference(p).getTitle()));
             }
+
+            positionReferences.add(model.getPositionReference(p));
         }
 
+        toAdd.setPositions(positionReferences);
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -92,19 +94,24 @@ public class EditCandidateCommand extends Command {
         }
 
         Set<Position> newPositions = editedPerson.getPositions();
+        Set<Position> positionReferences = new HashSet<>();
         for (Position p : newPositions) {
             if (!model.hasPosition(p)) {
-                throw new CommandException("Position " + p.getTitle().fullTitle + " not found in HR Manager");
+                throw new CommandException(String.format(MESSAGE_POSITION_DOES_NOT_EXIST, p.getTitle()));
             }
             if (model.isPositionClosed(p)) {
-                throw new CommandException("Position " + p.getTitle().fullTitle + " is closed");
+                throw new CommandException(String.format(MESSAGE_POSITION_CLOSED,
+                        model.getPositionReference(p).getTitle()));
             }
+            positionReferences.add(model.getPositionReference(p));
         }
+
+        editedPerson.setPositions(positionReferences);
 
         //Remove the old person and add the new one
         Set<Interview> interviews = personToEdit.getInterviews();
         for (Interview i : interviews) {
-            i.removeCandidate(personToEdit);
+            i.deleteCandidate(personToEdit);
             i.addCandidate(editedPerson);
         }
 

--- a/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/AddInterviewCommand.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 
 import java.util.HashSet;
 import java.util.List;
@@ -47,8 +49,6 @@ public class AddInterviewCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New interview added: %1$s";
     public static final String MESSAGE_DUPLICATE_INTERVIEW = "This interview already exists in the HR Manager";
-    public static final String MESSAGE_NO_POSITION_FOUND = "Position %1$s not found in HR Manager";
-    public static final String MESSAGE_POSITION_CLOSED = "Position %1$s is closed";
     public static final String MESSAGE_CANDIDATE_DID_NOT_APPLY = "Candidate %1$s did not apply for Position %2$s";
 
     private final Interview toAdd;
@@ -70,12 +70,14 @@ public class AddInterviewCommand extends Command {
 
         Position position = toAdd.getPosition();
         if (!model.hasPosition(position)) {
-            throw new CommandException(String.format(MESSAGE_NO_POSITION_FOUND, position.getTitle()));
+            throw new CommandException(String.format(MESSAGE_POSITION_DOES_NOT_EXIST, position.getTitle()));
         }
-
         if (model.isPositionClosed(position)) {
             throw new CommandException(String.format(MESSAGE_POSITION_CLOSED, position.getTitle()));
         }
+
+        toAdd.setPosition(model.getPositionReference(position));
+
         //loads candidates from set of index
         Set<Person> candidates = new HashSet<>();
         for (Index index : indexes) {

--- a/src/main/java/seedu/address/logic/interview/EditInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/EditInterviewCommand.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -110,9 +112,15 @@ public class EditInterviewCommand extends Command {
         }
 
         Position newPosition = editedInterview.getPosition();
-        if (model.isPositionClosed(newPosition)) {
-            throw new CommandException(Interview.MESSAGE_POSITION_CONSTRAINTS);
+        if (!model.hasPosition(newPosition)) {
+            throw new CommandException(String.format(MESSAGE_POSITION_DOES_NOT_EXIST, newPosition.getTitle()));
         }
+        if (model.isPositionClosed(newPosition)) {
+            throw new CommandException(String.format(MESSAGE_POSITION_CLOSED,
+                    model.getPositionReference(newPosition).getTitle()));
+        }
+        editedInterview.setPosition(model.getPositionReference(newPosition));
+
 
         model.setInterview(interviewToEdit, editedInterview);
         model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);

--- a/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/interview/UnassignInterviewCommand.java
@@ -104,7 +104,7 @@ public class UnassignInterviewCommand extends Command {
                     throw new CommandException(String.format(MESSAGE_CANDIDATE_DID_NOT_APPLY,
                             candidateIndex.getOneBased(), candidate.getName(), interview.getDisplayString()));
                 }
-                interview.removeCandidate(candidate);
+                interview.deleteCandidate(candidate);
                 candidate.deleteInterview(interview);
 
                 removedPersons.append(count + ". " + candidate.getName() + "\n");

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -77,7 +77,6 @@ public class EditPositionCommand extends Command {
         model.setPosition(positionToEdit, editedPosition);
         model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
 
-        // Save updated position in the candidates.json file. //TODO
         for (Person person : lastShownPersonList) {
             Set<Position> positions = person.getPositions();
             if (positions.contains(positionToEdit)) {

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -18,6 +18,7 @@ import seedu.address.logic.CommandResult;
 import seedu.address.logic.candidate.EditCandidateCommand;
 import seedu.address.logic.candidate.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.interview.Interview;
 import seedu.address.model.person.Person;
 import seedu.address.model.position.Position;
 import seedu.address.model.position.Position.PositionStatus;
@@ -57,15 +58,16 @@ public class EditPositionCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Position> lastShownList = model.getFilteredPositionList();
+        List<Position> lastShownPositionList = model.getFilteredPositionList();
         List<Person> lastShownPersonList = model.getFilteredPersonList();
+        List<Interview> lastShownInterviewList = model.getFilteredInterviewList();
 
         // Save updated position in the positions.json file.
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (index.getZeroBased() >= lastShownPositionList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_POSITION_DISPLAYED_INDEX);
         }
 
-        Position positionToEdit = lastShownList.get(index.getZeroBased());
+        Position positionToEdit = lastShownPositionList.get(index.getZeroBased());
         Position editedPosition = createEditedPosition(positionToEdit, editPositionDescriptor);
 
         if (!positionToEdit.isSamePosition(editedPosition) && model.hasPosition(editedPosition)) {
@@ -97,6 +99,13 @@ public class EditPositionCommand extends Command {
 
                 model.setPerson(person, editedPerson);
                 model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            }
+        }
+
+        for (Interview interview : lastShownInterviewList) {
+            Position interviewPosition = interview.getPosition();
+            if (interviewPosition.isSamePosition(positionToEdit)) {
+                interview.setPosition(editedPosition);
             }
         }
 

--- a/src/main/java/seedu/address/model/HrManager.java
+++ b/src/main/java/seedu/address/model/HrManager.java
@@ -134,6 +134,10 @@ public class HrManager implements ReadOnlyHrManager {
         return positions.contains(position);
     }
 
+    public Position getPosition(Position position) {
+        return positions.getPosition(position);
+    }
+
     /**
      * Adds a position to the HR Manager.
      * The position must not already exist in the HR Manager.
@@ -234,7 +238,7 @@ public class HrManager implements ReadOnlyHrManager {
     public void deletePersonFromInterview(Person person) {
         for (Interview interview : interviews) {
             if (interview.hasCandidate(person)) {
-                interview.removeCandidate(person);
+                interview.deleteCandidate(person);
             }
         }
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -131,6 +131,11 @@ public interface Model {
     boolean hasPosition(Position position);
 
     /**
+     * Returns the position stored in HR Manager {@code position}
+     */
+    Position getPositionReference(Position position);
+
+    /**
      * Deletes the given position.
      * The position must exist in the HR Manager.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -152,6 +152,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Position getPositionReference(Position position) {
+        return hrManager.getPosition(position);
+    }
+
+    @Override
     public void deletePosition(Position target) {
         hrManager.removePosition(target);
     }

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -32,7 +32,7 @@ public class Interview {
     public static final String MESSAGE_TIME_CONSTRAINTS = "Time should be be valid and in HHMM format.";
     public static final String MESSAGE_DURATION_CONSTRAINTS = "Duration should be a positive integer.";
 
-    private final Position position;
+    private Position position;
 
     private InterviewStatus status;
 
@@ -126,6 +126,10 @@ public class Interview {
     public Position getPosition() {
         assert this.position != null : "Interview position is non-null";
         return position;
+    }
+
+    public void setPosition(Position newPosition) {
+        position = newPosition;
     }
 
     public Set<Person> getCandidates() {
@@ -224,7 +228,7 @@ public class Interview {
         return candidates.contains(person);
     }
 
-    public void removeCandidate(Person person) {
+    public void deleteCandidate(Person person) {
         candidates.remove(person);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -233,4 +233,8 @@ public class Person {
     public void setInterviews(Set<Interview> personInterviews) {
         interviews.addAll(personInterviews);
     }
+
+    public void setPositions(Set<Position> personPositions) {
+        positions = personPositions;
+    }
 }

--- a/src/main/java/seedu/address/model/position/Position.java
+++ b/src/main/java/seedu/address/model/position/Position.java
@@ -9,6 +9,8 @@ import static java.util.Objects.requireNonNull;
 public class Position {
 
     public static final String MESSAGE_CONSTRAINTS = "Position names should be alphanumeric";
+    public static final String MESSAGE_POSITION_CLOSED = "Position %s is closed";
+    public static final String MESSAGE_POSITION_DOES_NOT_EXIST = "Position %s not found in HR Manager";
 
     public final Title title;
 

--- a/src/main/java/seedu/address/model/position/UniquePositionList.java
+++ b/src/main/java/seedu/address/model/position/UniquePositionList.java
@@ -97,6 +97,18 @@ public class UniquePositionList implements Iterable<Position> {
         internalList.setAll(positions);
     }
 
+
+    public Position getPosition(Position position) {
+        assert internalList.contains(position);
+
+        for (Position p : internalList) {
+            if (p.isSamePosition(position)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */

--- a/src/test/java/seedu/address/logic/candidate/AddCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/AddCandidateCommandTest.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.interview.AddInterviewCommand.MESSAGE_NO_POSITION_FOUND;
-import static seedu.address.logic.interview.AddInterviewCommand.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -61,7 +61,7 @@ public class AddCandidateCommandTest {
         Person validPerson = new PersonBuilder(ALICE).withPositions("Admin").build();
         ModelStubWithSomePositionsAndBob modelStub = new ModelStubWithSomePositionsAndBob();
         AddCandidateCommand addCandidateCommand = new AddCandidateCommand(validPerson);
-        String expectedMessage = String.format(MESSAGE_NO_POSITION_FOUND, "Admin");
+        String expectedMessage = String.format(MESSAGE_POSITION_DOES_NOT_EXIST, "Admin");
 
         assertThrows(CommandException.class, expectedMessage, () ->
                 addCandidateCommand.execute(modelStub));

--- a/src/test/java/seedu/address/logic/candidate/AddCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/AddCandidateCommandTest.java
@@ -150,6 +150,11 @@ public class AddCandidateCommandTest {
             return false;
         }
 
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
+        }
+
         //For some reason p.getStatus() is always open even when building with closed
         @Override
         public boolean isPositionClosed(Position p) {
@@ -193,6 +198,11 @@ public class AddCandidateCommandTest {
         @Override
         public boolean isPositionClosed(Position p) {
             return false;
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
     }
 }

--- a/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
@@ -11,8 +11,8 @@ import static seedu.address.logic.candidate.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.candidate.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.candidate.CommandTestUtil.assertEditCandidateCommandSuccess;
 import static seedu.address.logic.candidate.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.logic.interview.AddInterviewCommand.MESSAGE_NO_POSITION_FOUND;
-import static seedu.address.logic.interview.AddInterviewCommand.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -199,7 +199,7 @@ public class EditCandidateCommandTest {
         EditCandidateCommand editCandidateCommand = new EditCandidateCommand(INDEX_FIRST_PERSON,
                 editPersonDescriptor);
         ModelStubWithObservable modelStub = new ModelStubWithObservable();
-        String expectedMessage = String.format(MESSAGE_NO_POSITION_FOUND, "Admin");
+        String expectedMessage = String.format(MESSAGE_POSITION_DOES_NOT_EXIST, "Admin");
 
         assertThrows(CommandException.class, expectedMessage, () ->
                 editCandidateCommand.execute(modelStub));
@@ -261,6 +261,11 @@ public class EditCandidateCommandTest {
         @Override
         public void addPerson(Person person) {
             persons.add(person);
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/interview/AddInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/AddInterviewCommandTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.interview;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_DOES_NOT_EXIST;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -69,7 +71,7 @@ class AddInterviewCommandTest {
         AddInterviewCommand addInterviewCommand = new AddInterviewCommand(validInterview, new HashSet<>());
         ModelStubWithNoPosition modelStub = new ModelStubWithNoPosition();
 
-        assertThrows(CommandException.class, String.format(AddInterviewCommand.MESSAGE_NO_POSITION_FOUND,
+        assertThrows(CommandException.class, String.format(MESSAGE_POSITION_DOES_NOT_EXIST,
                 validInterview.getPosition().getTitle()), () -> addInterviewCommand.execute(modelStub));
     }
 
@@ -96,7 +98,7 @@ class AddInterviewCommandTest {
                 .withPosition(new Position(new Title("accountant"))).build();
         AddInterviewCommand addInterviewCommand = new AddInterviewCommand(interview, temp);
 
-        assertThrows(CommandException.class, String.format(AddInterviewCommand.MESSAGE_NO_POSITION_FOUND,
+        assertThrows(CommandException.class, String.format(MESSAGE_POSITION_DOES_NOT_EXIST,
                 "accountant"), () -> addInterviewCommand.execute(model));
     }
 
@@ -134,7 +136,7 @@ class AddInterviewCommandTest {
                 .build();
         AddInterviewCommand addInterviewCommand = new AddInterviewCommand(validInterview, temp);
 
-        assertThrows(CommandException.class, String.format(AddInterviewCommand.MESSAGE_POSITION_CLOSED,
+        assertThrows(CommandException.class, String.format(MESSAGE_POSITION_CLOSED,
                 "Admin"), () -> addInterviewCommand.execute(model));
     }
 
@@ -164,6 +166,11 @@ class AddInterviewCommandTest {
         @Override
         public boolean hasPosition(Position position) {
             return true;
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
 
         @Override
@@ -217,6 +224,11 @@ class AddInterviewCommandTest {
         @Override
         public boolean hasPosition(Position position) {
             return emptyPositionList.contains(position);
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
 
         @Override
@@ -290,6 +302,11 @@ class AddInterviewCommandTest {
         @Override
         public boolean hasPosition(Position position) {
             return true;
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/interview/EditInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/EditInterviewCommandTest.java
@@ -15,7 +15,6 @@ import static seedu.address.logic.interview.CommandTestUtil.assertEditInterviewC
 import static seedu.address.logic.interview.CommandTestUtil.showInterviewAtIndex;
 import static seedu.address.logic.interview.EditInterviewCommand.MESSAGE_CANDIDATE_DID_NOT_APPLY;
 import static seedu.address.logic.position.CommandTestUtil.VALID_TITLE_ADMIN_ASSISTANT;
-import static seedu.address.model.interview.Interview.MESSAGE_POSITION_CONSTRAINTS;
 import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_INTERVIEW;
@@ -217,8 +216,8 @@ public class EditInterviewCommandTest {
         descriptor.setPosition(CLOSED_POSITION_CLERK);
         EditInterviewCommand editInterviewCommand = new EditInterviewCommand(INDEX_FIRST_INTERVIEW, descriptor);
 
-        assertThrows(CommandException.class, String.format(MESSAGE_POSITION_CLOSED, CLOSED_POSITION_CLERK.getTitle()),
-                () -> editInterviewCommand.execute(modelStub));
+        assertThrows(CommandException.class, String.format(MESSAGE_POSITION_CLOSED,
+                CLOSED_POSITION_CLERK.getTitle()), () -> editInterviewCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/interview/EditInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/EditInterviewCommandTest.java
@@ -16,6 +16,7 @@ import static seedu.address.logic.interview.CommandTestUtil.showInterviewAtIndex
 import static seedu.address.logic.interview.EditInterviewCommand.MESSAGE_CANDIDATE_DID_NOT_APPLY;
 import static seedu.address.logic.position.CommandTestUtil.VALID_TITLE_ADMIN_ASSISTANT;
 import static seedu.address.model.interview.Interview.MESSAGE_POSITION_CONSTRAINTS;
+import static seedu.address.model.position.Position.MESSAGE_POSITION_CLOSED;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_INTERVIEW;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_INTERVIEW;
@@ -216,8 +217,8 @@ public class EditInterviewCommandTest {
         descriptor.setPosition(CLOSED_POSITION_CLERK);
         EditInterviewCommand editInterviewCommand = new EditInterviewCommand(INDEX_FIRST_INTERVIEW, descriptor);
 
-        assertThrows(CommandException.class,
-                MESSAGE_POSITION_CONSTRAINTS, () -> editInterviewCommand.execute(modelStub));
+        assertThrows(CommandException.class, String.format(MESSAGE_POSITION_CLOSED, CLOSED_POSITION_CLERK.getTitle()),
+                () -> editInterviewCommand.execute(modelStub));
     }
 
     @Test
@@ -297,6 +298,16 @@ public class EditInterviewCommandTest {
         @Override
         public boolean isPositionClosed(Position toCheck) {
             return toCheck.getStatus() == Position.PositionStatus.CLOSED;
+        }
+
+        @Override
+        public boolean hasPosition(Position position) {
+            return true;
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
@@ -36,6 +36,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyHrManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.interview.Interview;
 import seedu.address.model.person.Person;
 import seedu.address.model.position.Position;
 import seedu.address.testutil.EditPositionDescriptorBuilder;
@@ -210,6 +211,7 @@ public class EditPositionCommandTest {
     private class ModelStubAcceptingPositionEdited extends ModelStub {
         final ObservableList<Position> positions = FXCollections.observableArrayList();
         final ObservableList<Person> persons = FXCollections.observableArrayList();
+        final ObservableList<Interview> interviews = FXCollections.observableArrayList();
 
         ModelStubAcceptingPositionEdited() {
             persons.add(JOHN);
@@ -221,6 +223,11 @@ public class EditPositionCommandTest {
         public boolean hasPosition(Position position) {
             requireNonNull(position);
             return positions.stream().anyMatch(position::isSamePosition);
+        }
+
+        @Override
+        public Position getPositionReference(Position position) {
+            return position;
         }
 
         @Override
@@ -248,6 +255,11 @@ public class EditPositionCommandTest {
         @Override
         public ObservableList<Person> getFilteredPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Interview> getFilteredInterviewList() {
+            return interviews;
         }
 
         @Override

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -94,6 +94,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public Position getPositionReference(Position position) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void deletePosition(Position target) {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
-Updated commands that take in position such that regardless of what the user inputs, the position that is stored has the same naming convention as the one in the positionlist.
    - e.g If BOOKkeeper is stored in the positionlist, add_c position=bookkeeper, will store BOOKkeeper inside the candidate object.

-Updated Position error messages to be stored in Position.java instead of elsewhere.
-Updated EditPosition such that is also changes the title for Interview objects
-Updated relevant test cases
-Renamed Interview::removeCandidate to Interview::deleteCandidate to be inline with other removal commands

Fix #206