### PR TITLE
Update parseCandidateIndexes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInterviewCommandParser.java
@@ -42,7 +42,7 @@ public class AddInterviewCommandParser implements Parser<AddInterviewCommand> {
         }
 
         Position position = ParserUtil.parsePosition(argMultimap.getValue(PREFIX_POSITION).get());
-        Set<Index> indexes = ParserUtil.parseCandidateIndex(argMultimap.getValue(PREFIX_CANDIDATE_INDEX).get());
+        Set<Index> indexes = ParserUtil.parseCandidateIndexes(argMultimap.getValue(PREFIX_CANDIDATE_INDEX).get());
         LocalDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         LocalTime time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
         Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());

--- a/src/main/java/seedu/address/logic/parser/AssignInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignInterviewCommandParser.java
@@ -34,7 +34,7 @@ public class AssignInterviewCommandParser implements Parser<AssignInterviewComma
         Set<Index> candidateIndexes;
         String candidateIndexInput = argMultimap.getValue(PREFIX_CANDIDATE_INDEX).get();
 
-        candidateIndexes = ParserUtil.parseCandidateIndex(candidateIndexInput);
+        candidateIndexes = ParserUtil.parseCandidateIndexes(candidateIndexInput);
         return new AssignInterviewCommand(interviewIndex, candidateIndexes);
 
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -395,7 +396,7 @@ public class ParserUtil {
      * @return A Set of Indexes for Candidates.
      * @throws ParseException If the given {@code indexes} is invalid
      */
-    public static Set<Index> parseCandidateIndex(String indexes) throws ParseException {
+    public static Set<Index> parseCandidateIndexes(String indexes) throws ParseException {
         requireNonNull(indexes);
         String trimmedKeywords = indexes.trim();
         Set<Index> characterIndexes = new HashSet<>();
@@ -404,7 +405,11 @@ public class ParserUtil {
 
         temp.removeAll(Arrays.asList(""));
 
-        for (String index : temp) {
+        List<String> tempWithoutDuplicates = temp.stream()
+                .distinct()
+                .collect(Collectors.toList());
+
+        for (String index : tempWithoutDuplicates) {
             characterIndexes.add(parseIndex(index));
         }
 

--- a/src/main/java/seedu/address/logic/parser/UnassignInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignInterviewCommandParser.java
@@ -35,7 +35,7 @@ public class UnassignInterviewCommandParser implements Parser<UnassignInterviewC
         if (candidateIndexInput.equals("*")) {
             return new UnassignInterviewCommand(interviewIndex, true);
         } else {
-            candidateIndexes = ParserUtil.parseCandidateIndex(candidateIndexInput);
+            candidateIndexes = ParserUtil.parseCandidateIndexes(candidateIndexInput);
             return new UnassignInterviewCommand(interviewIndex, candidateIndexes);
         }
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,6 +14,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -257,5 +259,49 @@ public class ParserUtilTest {
     @Test
     public void parseTime_invalidValueNoPatternFound_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseTime("22222"));
+    }
+
+    @Test
+    public void parseCandidateIndexes_validValues_returnsCandidateIndexes() throws ParseException{
+        Set<Index> indexes = new HashSet<>();
+        indexes.add(INDEX_FIRST_PERSON);
+        indexes.add(INDEX_SECOND_PERSON);
+
+        Set<Index> test = ParserUtil.parseCandidateIndexes("2 1");
+
+        Set<Integer> indexesInIntegers = new HashSet<>();
+        Set<Integer> testAsIntegers = new HashSet<>();
+
+        for (Index index : indexes) {
+            indexesInIntegers.add(index.getZeroBased());
+        }
+
+        for (Index index : test) {
+            testAsIntegers.add(index.getZeroBased());
+        }
+
+        assertEquals(indexesInIntegers, testAsIntegers);
+    }
+
+    @Test
+    public void parseCandidateIndex_duplicateValues_removesDuplicates() throws ParseException{
+        Set<Index> indexes = new HashSet<>();
+        indexes.add(INDEX_FIRST_PERSON);
+        indexes.add(INDEX_SECOND_PERSON);
+
+        Set<Index> test = ParserUtil.parseCandidateIndexes("2 1 2 2 2 2 2 2 2 2 2 2 1 1");
+
+        Set<Integer> indexesInIntegers = new HashSet<>();
+        Set<Integer> testAsIntegers = new HashSet<>();
+
+        for (Index index : indexes) {
+            indexesInIntegers.add(index.getZeroBased());
+        }
+
+        for (Index index : test) {
+            testAsIntegers.add(index.getZeroBased());
+        }
+
+        assertEquals(indexesInIntegers, testAsIntegers);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -262,7 +262,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseCandidateIndexes_validValues_returnsCandidateIndexes() throws ParseException{
+    public void parseCandidateIndexes_validValues_returnsCandidateIndexes() throws ParseException {
         Set<Index> indexes = new HashSet<>();
         indexes.add(INDEX_FIRST_PERSON);
         indexes.add(INDEX_SECOND_PERSON);
@@ -284,7 +284,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseCandidateIndex_duplicateValues_removesDuplicates() throws ParseException{
+    public void parseCandidateIndexes_duplicateValues_returnsCandidateIndexesWithoutDuplicates() throws ParseException {
         Set<Index> indexes = new HashSet<>();
         indexes.add(INDEX_FIRST_PERSON);
         indexes.add(INDEX_SECOND_PERSON);


### PR DESCRIPTION
-Renamed parseCandidateIndex to parseCandidateIndexes to better represent what the method does.
-Updated parseCandidateIndexes to remove duplicates from input.

Fix #198