### PR TITLE
Update ug interview and position section

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -107,6 +107,16 @@ Manage a list of job positions posted by your company, with the simple instructi
   <br>
   <br>
 
+#### <u>List all positions:</u> `list_p`
+
+*Displays a list of all the positions stored in the application.*
+
+<u>Format:</u>
+
+    list_p
+
+  <br>
+
 #### <u>Delete a position:</u> `delete_p`
 
 *Deletes a position from the list of positions.*
@@ -121,17 +131,6 @@ Manage a list of job positions posted by your company, with the simple instructi
 
 * Deletes the 3rd position from the list of positions.
 * Also deletes this position from every candidate who applied for the position
-  <br>
-  <br>
-
-#### <u>List all positions:</u> `list_p`
-
-*Displays a list of all the positions stored in the application.*
-
-<u>Format:</u>
-
-    list_p
-
   <br>
   <br>
 
@@ -220,6 +219,16 @@ Each candidate is uniquely identified by the same name, email and phone number. 
     <br>
     <br>
 
+#### <u>List all candidates:</u> `list_c`
+
+*Displays a list of all the candidates stored in the application.*
+
+<u>Format:</u>
+
+    list_c
+
+  <br>
+
 #### <u>Delete a candidate:</u> `delete_c`
 
 *Deletes a candidate along with his/her details from the list of candidates.*
@@ -235,17 +244,7 @@ Each candidate is uniquely identified by the same name, email and phone number. 
 * Deletes the 3rd candidate along with his/her details from the list of candidates.
   <br>
   <br>
-
-#### <u>List all candidates:</u> `list_c`
-
-*Displays a list of all the candidates stored in the application.*
-
-<u>Format:</u>
-
-    list_c
-
-  <br>
-  <br>
+  
 
 #### <u>Remark a candidate:</u> `remark_c`
 
@@ -342,7 +341,6 @@ Input fields of all interview commands should follow the following formats:
 </div>
 
   <br>
-  <br>
 
 #### <u>Add an interview:</u> `add_i`
 
@@ -359,6 +357,19 @@ Input fields of all interview commands should follow the following formats:
 * Adds an interview for the position of Accountant, for the 1st and 2nd candidates in the candidate list.
   The interview is scheduled to be on 18 October 2020, at 2p.m. and has a duration of 120 minutes. The interview's
   status is also provided as "pending", meaning that the interview has yet to be completed.
+  
+  <br>
+  <br>
+
+#### <u>List all interviews:</u> `list_i`
+
+*Displays a list of all the interviews stored in the application.*
+
+<u>Format:</u>
+
+    list_i
+
+  <br>
 
 #### <u>Delete an interview:</u> `delete_i`
 
@@ -396,16 +407,6 @@ Edits a specific interview in the list of interviews.
   `c=1 2` for the candidates assigned to the interview, `date=18/10/2021` for the date of the interview and `time=1400`
   for the time the interview is scheduled for.
   <br>
-  <br>
-
-#### <u>List all interviews:</u> `list_i`
-
-*Displays a list of all the interviews stored in the application.*
-
-<u>Format:</u>
-
-    list_i
-
   <br>
 
 #### <u>Unassign candidates from interview:</u> `unassign`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -293,21 +293,12 @@ Each candidate is uniquely identified by the same name, email and phone number. 
 
 ### Feature: Interview Management
 
-Manage a list of interviews for you to select the desired candidates, with the simple instructions below!
+Manage a list of scheduled interviews, with the simple instructions below!
 
-#### <u>Add an interview:</u> `add_i`
+<div markdown="block" class="alert alert-info">
+**Notes on the command format:**
 
-*Adds an interview to the list of interviews.*
-
-<u>Format:</u>
-
-    add_i position=<POSITION> index=<INDEX>... date=DATE time=TIME duration=DURATION [interviewed=STATUS]
-
-<u>Example:</u>
-
-    add_i position=Accountant c=1 2 date=18/10/2021 time=1400 duration=120 interviewed=pending
-
-* Adds an interview with the position of Accountant and the 1st and 2nd candidate in the list.
+Parameters of all interview commands should follow the following formats: 
 * `POSITION` must be added to HR Manager and must have been applied by corresponding candidates before it can be used as a parameter.
   * e.g., if the position, `Accountant` has not been added to HR Manager, the above command will result in an error : `Position Accountant not found in HR Manager`
 * `DATE` must be in numbers in DD/MM/YYYY form and can tolerate single digit for day and month, but year must be 4 digits.
@@ -321,6 +312,23 @@ Manage a list of interviews for you to select the desired candidates, with the s
   * e.g., if the status, `tbc` was used instead, HR Manager will show an error :`Interview Status can ony take the values:pending completed`
     <br>
     <br>
+</div>
+
+#### <u>Add an interview:</u> `add_i`
+
+*Adds an interview to the list of interviews.*
+
+<u>Format:</u>
+
+    add_i position=<POSITION> index=<INDEX>... date=DATE time=TIME duration=DURATION [interviewed=STATUS]
+
+<u>Example:</u>
+
+    add_i position=Accountant c=1 2 date=18/10/2021 time=1400 duration=120 interviewed=pending
+
+* Adds an interview for the position of Accountant, for the 1st and 2nd candidates in the candidate list.
+  The interview is scheduled to be on 18 October 2020, at 2p.m. and has a duration of 120 minutes. The interview's
+  status is also provided as "pending", meaning that the interview has yet to be completed.
 
 #### <u>Delete an interview:</u> `delete_i`
 
@@ -346,13 +354,15 @@ Edits a specific interview in the list of interviews.
 
 <u>Format:</u>
 
-    edit_i <INDEX> [position=POSITION]... [c=<CANDIDATE INDEX>]... [date=DATE]... [time=TIME]... [duration=DURATION]... [interviewed=STATUS]...
+    edit_i <INDEX> [position=POSITION]... [c=<CANDIDATE INDEX>]... [date=DATE]... [time=TIME]...
+    [duration=DURATION]... [interviewed=STATUS]...
 
 <u>Example:</u>
 `edit_i 2 c=1 2 date=18/10/2021 time=1400`
 * Edits the second interview in the interview list and updates the candidate set, date and time of the interview.
-* Similar to `add_i` command, POSITION, DATE, TIME, DURATION AND STATUS must be valid inputs.
-* At least one field must be edited.
+* All input fields should be provided in the correct format. Please refer to notes on interview command format shown
+  above to see what constitutes a valid input.
+* At least one input field must be edited.
   <br>
   <br>
 
@@ -364,7 +374,6 @@ Edits a specific interview in the list of interviews.
 
     list_i
 
-  <br>
   <br>
 
 #### <u>Unassign candidates from interview:</u> `unassign`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -298,7 +298,7 @@ Manage a list of scheduled interviews, with the simple instructions below!
 <div markdown="block" class="alert alert-info">
 **Notes on the command format:**
 
-Parameters of all interview commands should follow the following formats: 
+Input fields of all interview commands should follow the following formats: 
 * `POSITION` must be added to HR Manager and must have been applied by corresponding candidates before it can be used as a parameter.
   * e.g., if the position, `Accountant` has not been added to HR Manager, the above command will result in an error : `Position Accountant not found in HR Manager`
 * `DATE` must be in numbers in DD/MM/YYYY form and can tolerate single digit for day and month, but year must be 4 digits.
@@ -310,9 +310,10 @@ Parameters of all interview commands should follow the following formats:
   * e.g., if the duration, `twenty` was used instead, HR Manager will show an error : `Duration should be in numbers.`
 * `STATUS` must be either `pending` or `completed`
   * e.g., if the status, `tbc` was used instead, HR Manager will show an error :`Interview Status can ony take the values:pending completed`
-    <br>
-    <br>
 </div>
+
+  <br>
+  <br>
 
 #### <u>Add an interview:</u> `add_i`
 
@@ -362,7 +363,9 @@ Edits a specific interview in the list of interviews.
 * Edits the second interview in the interview list and updates the candidate set, date and time of the interview.
 * All input fields should be provided in the correct format. Please refer to notes on interview command format shown
   above to see what constitutes a valid input.
-* At least one input field must be edited.
+* At least one input field must be edited. For instance, in the above example, three input fields have been edited - 
+  `c=1 2` for the candidates assigned to the interview, `date=18/10/2021` for the date of the interview and `time=1400`
+  for the time the interview is scheduled for.
   <br>
   <br>
 
@@ -378,7 +381,7 @@ Edits a specific interview in the list of interviews.
 
 #### <u>Unassign candidates from interview:</u> `unassign`
 
-*Unassigns candidates from interview*
+*Unassigns candidates from a specified interview.*
 
 <u>Format:</u>
 
@@ -387,7 +390,7 @@ Edits a specific interview in the list of interviews.
 <u>Example:</u>
 `unassign i=1 c=2 4`
 
-* You can only input any number of candidates but only 1 interview.
+* You can input any number of candidates but only 1 interview.
 * Removes candidates with candidate index 2 and 4 from the first interview.
 * Inputting `c=*` removes all candidates from an interview.
   <br>
@@ -395,7 +398,7 @@ Edits a specific interview in the list of interviews.
 
 #### <u>Assign candidates to interview:</u> `assign`
 
-*Assigns candidates to interview*
+*Assigns candidates to a specified interview.*
 
 <u>Format:</u>
 
@@ -406,24 +409,33 @@ Edits a specific interview in the list of interviews.
 
 * You can input any number of candidates but only 1 interview.
 * Adds candidates with candidate index 2 and 4 to the first interview.
-* NOTE: If the candidate has not applied to the position, attempting to assign the candidate to an interview
+
+<div markdown="block" class="alert alert-info">
+**WARNING:**
+* If the candidate has not applied to the position, attempting to assign the candidate to an interview
   for that position will result in an error message displayed.
+</div>
   <br>
   <br>
 
-#### <u>Find a Interview:</u> `find_i`
+#### <u>Find an Interview:</u> `find_i`
 
 *Filters the candidate list based on the parameters provided. Minimum of 1 field is needed. Searching is case-insensitive*
 
 <u>Format:</u>
 
-    find_i [position=POSITION]... [c=<Candidate Name>]... [date=DATE]... [time=TIME]... [duration=DURATION]... [interviewed=STATUS]...
+    find_i [position=POSITION]... [c=<Candidate Name>]... [date=DATE]... [time=TIME]...
+    [duration=DURATION]... [interviewed=STATUS]...
 
 <u>Example:</u>
 
     find_i date=21/09/2021 time=1600
 
 * Finds all interviews that are on 21/09/2021 and occur on 1600
+
+<div markdown="block" class="alert alert-info">
+**NOTE:**
+
 * Interviews that will be found
   * date="21/09/2021", time="1500-1700"
   * date="21/09/2021", time="1600-1650"
@@ -434,7 +446,7 @@ Edits a specific interview in the list of interviews.
   * Command will find candidates that contains at least 1 of the keywords (OR)
 * Across different fields
   * Command will return candidates that contain all the fields (AND)
-
+</div>
   <br>
   <br>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -328,26 +328,6 @@ Each candidate is uniquely identified by the same name, email and phone number. 
 
 Manage a list of scheduled interviews, with the simple instructions below!
 
-<div markdown="block" class="alert alert-info">
-
-**Notes on the command format:**
-
-Input fields of all interview commands should follow the following formats: 
-* `POSITION` must be added to HR Manager and must have been applied by corresponding candidates before it can be used as a parameter.
-  * e.g., if the position, `Accountant` has not been added to HR Manager, the above command will result in an error : `Position Accountant not found in HR Manager`
-* `DATE` must be in numbers in DD/MM/YYYY form and can tolerate single digit for day and month, but year must be 4 digits.
-  * e.g., if the date, `2021/10/18` was used instead, HR Manager will show an error : `Date should be be valid and in DD/MM/YYYY format.`
-  * e.g., if the date, `18 Oct 21` was used instead, HR Manager will show an error : `Date should be be valid and in DD/MM/YYYY format.`
-* `TIME` must be in HHMM form, following 24-hour form, e.g., `1800` and `0600` for 6 P.M. and 6 A.M. respectively
-  * e.g., if the time, `6pm` was used instead, HR Manager will show an error : `Time should be be valid and in HHMM format..`
-* `DURATION` must be in numbers and is set to be in minutes
-  * e.g., if the duration, `twenty` was used instead, HR Manager will show an error : `Duration should be in numbers.`
-* `STATUS` must be either `pending` or `completed`
-  * e.g., if the status, `tbc` was used instead, HR Manager will show an error :`Interview Status can ony take the values:pending completed`
-</div>
-
-  <br>
-
 #### <u>Add an interview:</u> `add_i`
 
 *Adds an interview to the list of interviews.*

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,6 +42,12 @@ transferable to other devices too!
 
 * **`clear`** : Deletes all candidates, positions, interviews.
 
+<div markdown="block" class="alert alert-info">
+
+WARNING: Please note that `clear` is an irreversible command and all existing data will be permanently deleted.
+
+</div>
+
 * **`exit`** : Exits the app.
 
 6. Refer to the [Features](#features) below for details of each command.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,9 +77,20 @@ transferable to other devices too!
 
 Manage a list of job positions posted by your company, with the simple instructions below!
 
+<div markdown="block" class="alert alert-info">
+
+**Notes:**<br>
+
+* Each position consists of a job position title, e.g. 'Accountant', 'Business Analyst', etc and a
+  position status that is either 'open' or 'closed'.
+  
+* Valid input for position status only include 'open' and 'closed'. E.g.`status=open` or `status=closed`.
+
+</div>
+
 #### <u>Add a position:</u> `add_p`
 
-*Adds a position to the list of positions.*
+*Adds a job position to the list of positions.*
 
 <u>Format:</u>
 
@@ -89,7 +100,10 @@ Manage a list of job positions posted by your company, with the simple instructi
 
     add_p title=Assistant
 
-* Adds a position with the title of Assistant.
+* Adds a job position with the title of Assistant, with a default status of 'open'.
+  
+* Adding a job position always sets the position status to 'open'. Refer to `edit_p` on how you can change the status
+  of a job position to 'closed'.
   <br>
   <br>
 
@@ -123,19 +137,33 @@ Manage a list of job positions posted by your company, with the simple instructi
 
 #### <u>Edit a position:</u> `edit_p`
 
-*Edits a specific position's details. Only one edit field is needed. Users cannot edit both fields.*
+*Edits a specific position's details. Only one edit field is needed, but users cannot edit both fields.
+  For instance, you can either choose to edit the title of a position, or the status of the position,
+  but not both at the same time.*
 
 <u>Format:</u>
 
-    edit_p <INDEX> [title=<TITLE>]... [status=<STATUS>]...
+    edit_p <INDEX> [title=<TITLE>]
 
+OR<br> 
+
+    edit_p <INDEX> [status=<STATUS>]
 <u>Example:</u>
 
+    edit_p 2 title=Data Analyst
+
+* Edits the title of the 2nd position in the list to 'Data Analyst'.
+  
+* Editing the title  of the specified position will update the position title in any scheduled interviews for
+  that position, along with any candidates who have applied for that position.
+  <br>
+  <br>
+
+    
     edit_p 3 status=closed
 
 * Edits the status of the 3rd position in the list to closed.
 * Setting position status to close will delete the position from every candidate who applied for the position.
-* At least one field must be edited.
   <br>
   <br>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -296,6 +296,7 @@ Each candidate is uniquely identified by the same name, email and phone number. 
 Manage a list of scheduled interviews, with the simple instructions below!
 
 <div markdown="block" class="alert alert-info">
+
 **Notes on the command format:**
 
 Input fields of all interview commands should follow the following formats: 
@@ -411,6 +412,7 @@ Edits a specific interview in the list of interviews.
 * Adds candidates with candidate index 2 and 4 to the first interview.
 
 <div markdown="block" class="alert alert-info">
+
 **WARNING:**
 * If the candidate has not applied to the position, attempting to assign the candidate to an interview
   for that position will result in an error message displayed.
@@ -434,6 +436,7 @@ Edits a specific interview in the list of interviews.
 * Finds all interviews that are on 21/09/2021 and occur on 1600
 
 <div markdown="block" class="alert alert-info">
+
 **NOTE:**
 
 * Interviews that will be found


### PR DESCRIPTION
Edit Interview section.
- included a block for valid parameter inputs at the beginning of the interview section. 
- fixed the preface to make it more coherent
- added more explanation to edit_i
- fixed some grammatical errors

Edit position section:
- included more details in preface, eg what constitutes a position: title + status
- made it clearer for edit_p that only one field can be edited
- split example for edit_p to editing title and editing status to make it clear that only one field can be edited

Features section:
Also included a warning label for the clear command.