### PR TITLE
Update command result message regarding large integer user input

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCandidateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCandidateCommandParser.java
@@ -22,7 +22,7 @@ public class DeleteCandidateCommandParser implements Parser<DeleteCandidateComma
             return new DeleteCandidateCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                            + "\n" + DeleteCandidateCommand.MESSAGE_USAGE, pe);
+                            + DeleteCandidateCommand.MESSAGE_USAGE, pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCandidateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCandidateCommandParser.java
@@ -21,8 +21,8 @@ public class DeleteCandidateCommandParser implements Parser<DeleteCandidateComma
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCandidateCommand(index);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCandidateCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                            + "\n" + DeleteCandidateCommand.MESSAGE_USAGE, pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteInterviewCommandParser.java
@@ -18,8 +18,8 @@ public class DeleteInterviewCommandParser implements Parser<DeleteInterviewComma
             Index index = ParserUtil.parseIndex(args);
             return new DeleteInterviewCommand(index);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteInterviewCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                    + "\n" + DeleteInterviewCommand.MESSAGE_USAGE, pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteInterviewCommandParser.java
@@ -19,7 +19,7 @@ public class DeleteInterviewCommandParser implements Parser<DeleteInterviewComma
             return new DeleteInterviewCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                    + "\n" + DeleteInterviewCommand.MESSAGE_USAGE, pe);
+                    + DeleteInterviewCommand.MESSAGE_USAGE, pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeletePositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePositionCommandParser.java
@@ -20,8 +20,8 @@ public class DeletePositionCommandParser implements Parser<DeletePositionCommand
             Index index = ParserUtil.parseIndex(args);
             return new DeletePositionCommand(index);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePositionCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                    + "\n" + DeletePositionCommand.MESSAGE_USAGE, pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeletePositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePositionCommandParser.java
@@ -21,7 +21,7 @@ public class DeletePositionCommandParser implements Parser<DeletePositionCommand
             return new DeletePositionCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                    + "\n" + DeletePositionCommand.MESSAGE_USAGE, pe);
+                    + DeletePositionCommand.MESSAGE_USAGE, pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCandidateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCandidateCommandParser.java
@@ -43,7 +43,7 @@ public class EditCandidateCommandParser implements Parser<EditCandidateCommand> 
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                    + "\n" + EditCandidateCommand.MESSAGE_USAGE, pe);
+                    + EditCandidateCommand.MESSAGE_USAGE, pe);
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/main/java/seedu/address/logic/parser/EditCandidateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCandidateCommandParser.java
@@ -42,8 +42,8 @@ public class EditCandidateCommandParser implements Parser<EditCandidateCommand> 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCandidateCommand.MESSAGE_USAGE),
-                    pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                    + "\n" + EditCandidateCommand.MESSAGE_USAGE, pe);
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/main/java/seedu/address/logic/parser/EditInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditInterviewCommandParser.java
@@ -36,7 +36,7 @@ public class EditInterviewCommandParser implements Parser<EditInterviewCommand> 
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                    + "\n" + EditInterviewCommand.MESSAGE_USAGE, pe);
+                    + EditInterviewCommand.MESSAGE_USAGE, pe);
         }
 
         EditInterviewCommand.EditInterviewDescriptor editInterviewDescriptor =

--- a/src/main/java/seedu/address/logic/parser/EditInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditInterviewCommandParser.java
@@ -35,8 +35,8 @@ public class EditInterviewCommandParser implements Parser<EditInterviewCommand> 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditInterviewCommand.MESSAGE_USAGE),
-                    pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                    + "\n" + EditInterviewCommand.MESSAGE_USAGE, pe);
         }
 
         EditInterviewCommand.EditInterviewDescriptor editInterviewDescriptor =

--- a/src/main/java/seedu/address/logic/parser/EditPositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditPositionCommandParser.java
@@ -23,7 +23,7 @@ public class EditPositionCommandParser implements Parser<EditPositionCommand> {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                    + "\n" + EditPositionCommand.MESSAGE_USAGE, pe);
+                    + EditPositionCommand.MESSAGE_USAGE, pe);
         }
 
         EditPositionCommand.EditPositionDescriptor editPositionDescriptor =

--- a/src/main/java/seedu/address/logic/parser/EditPositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditPositionCommandParser.java
@@ -22,8 +22,8 @@ public class EditPositionCommandParser implements Parser<EditPositionCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditPositionCommand.MESSAGE_USAGE),
-                    pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                    + "\n" + EditPositionCommand.MESSAGE_USAGE, pe);
         }
 
         EditPositionCommand.EditPositionDescriptor editPositionDescriptor =

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,15 +37,20 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX =
-            "Index is not a non-zero unsigned integer, or bigger than maximum value (2147483647).";
+            "Index should be a non-zero unsigned integer, and less than the maximum value (2147483647).\n";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (trimmedIndex.equals("")) {
+            throw new ParseException("");
+        }
+
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
@@ -54,6 +59,7 @@ public class ParserUtil {
 
     /**
      * Parses a string of keywords as List delimited by space.
+     *
      * @param keywords Input String.
      * @return List of keywords.
      */
@@ -70,6 +76,7 @@ public class ParserUtil {
 
     /**
      * Parses a string of time keyword delimited by spaces.
+     *
      * @param keywords Input String.
      * @return List of LocalTimes.
      * @throws ParseException Input string is not valid time format HHMM.
@@ -110,6 +117,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param name Input String.
      * @return Name of a candidate.
      * @throws ParseException if the given {@code name} is invalid.
@@ -126,6 +134,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param tag Input String.
      * @return Tag of a candidate.
      * @throws ParseException if the given {@code tag} is invalid.
@@ -142,6 +151,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String phone} into a {@code Phone}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param phone Input String.
      * @return Phone Number of a candidate.
      * @throws ParseException if the given {@code phone} is invalid.
@@ -158,6 +168,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String address} into an {@code Address}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param address Input String.
      * @return Address of a candidate.
      * @throws ParseException if the given {@code address} is invalid.
@@ -174,6 +185,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String email} into an {@code Email}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param email Input String.
      * @return Email of a candidate.
      * @throws ParseException if the given {@code email} is invalid.
@@ -190,6 +202,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String status} into a {@code Status}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param status Input String.
      * @return Status of a candidate.
      * @throws ParseException If the given {@code status} is invalid.
@@ -205,6 +218,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
+     *
      * @param tags Input Strings.
      * @return Tags of a candidate.
      * @throws ParseException If the given {@code tags} is invalid.
@@ -221,6 +235,7 @@ public class ParserUtil {
     /**
      * Parses {@code String title} into a {@code Title}
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param title Input String.
      * @return Title of a Job Position.
      * @throws ParseException If the given {@code title} is invalid.
@@ -237,6 +252,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String position} into a {@code Position}.
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param position Input String.
      * @return A Job Position.
      * @throws ParseException If the given {@code position} is invalid.
@@ -255,6 +271,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code Collection<String> position} into a {@code Set<Position>}.
+     *
      * @param positions Input Strings.
      * @return A Set of Job Positions.
      * @throws ParseException If the given {@code positions} is invalid.
@@ -270,6 +287,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code String positionStatus} into a {@code PositionStatus}.
+     *
      * @param positionStatus Input String.
      * @return Status of a Job Position.
      * @throws ParseException If the given {@code positionStatus} is invalid
@@ -291,6 +309,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code String date} into a {@code LocalDate}.
+     *
      * @param date Input String.
      * @return LocalDate of an Interview.
      * @throws ParseException If the given {@code date} is invalid
@@ -315,6 +334,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code String time} into a {@code LocalTime}.
+     *
      * @param time Input String.
      * @return LocalTime of an Interview.
      * @throws ParseException If the given {@code time} is invalid
@@ -337,6 +357,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code String duration} into a {@code Duration}.
+     *
      * @param duration Input String.
      * @return Duration of an Interview.
      * @throws ParseException If the given {@code duration} is invalid
@@ -357,6 +378,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String status} into a {@code InterviewStatus}
      * Leading and trailing whitespaces will be trimmed.
+     *
      * @param status Input String.
      * @return InterviewStatus of an Interview.
      * @throws ParseException If the given {@code status} is invalid
@@ -378,6 +400,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code Collection<String> indexes} into a {@code Set<Index>}.
+     *
      * @param indexes Input Strings.
      * @return A Set of Indexes.
      * @throws ParseException If the given {@code indexes} is invalid
@@ -393,6 +416,7 @@ public class ParserUtil {
 
     /**
      * Parses {@code String indexes} into a {@code Set<Index>}.
+     *
      * @param indexes Input Strings.
      * @return A Set of Indexes for Candidates.
      * @throws ParseException If the given {@code indexes} is invalid

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -36,7 +36,8 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX =
+            "Index is not a non-zero unsigned integer, or bigger than maximum value.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,7 +37,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX =
-            "Index is not a non-zero unsigned integer, or bigger than maximum value.";
+            "Index is not a non-zero unsigned integer, or bigger than maximum value (2147483647).";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/address/logic/parser/RemarkCandidateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCandidateCommandParser.java
@@ -27,7 +27,7 @@ public class RemarkCandidateCommandParser implements Parser<RemarkCandidateComma
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ive.getMessage())
-                    + "\n" + RemarkCandidateCommand.MESSAGE_USAGE, ive);
+                    + RemarkCandidateCommand.MESSAGE_USAGE, ive);
         }
 
         Remark remark = new Remark(argMultimap.getValue(PREFIX_REMARK).orElse(""));

--- a/src/main/java/seedu/address/logic/parser/RemarkCandidateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCandidateCommandParser.java
@@ -26,8 +26,8 @@ public class RemarkCandidateCommandParser implements Parser<RemarkCandidateComma
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemarkCandidateCommand.MESSAGE_USAGE), ive);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ive.getMessage())
+                    + "\n" + RemarkCandidateCommand.MESSAGE_USAGE, ive);
         }
 
         Remark remark = new Remark(argMultimap.getValue(PREFIX_REMARK).orElse(""));

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -30,7 +30,8 @@ public class Interview {
     public static final String MESSAGE_POSITION_CONSTRAINTS = "Position is closed or does not exist.";
     public static final String MESSAGE_DATE_CONSTRAINTS = "Date should be valid and in DD/MM/YYYY format.";
     public static final String MESSAGE_TIME_CONSTRAINTS = "Time should be be valid and in HHMM format.";
-    public static final String MESSAGE_DURATION_CONSTRAINTS = "Duration should be a positive integer.";
+    public static final String MESSAGE_DURATION_CONSTRAINTS =
+            "Duration should be a positive integer and less than 1 day (1440 minutes).";
 
     private Position position;
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCandidateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCandidateCommandParserTest.java
@@ -28,6 +28,6 @@ public class DeleteCandidateCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + DeleteCandidateCommand.MESSAGE_USAGE);
+                ParserUtil.MESSAGE_INVALID_INDEX) + DeleteCandidateCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCandidateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCandidateCommandParserTest.java
@@ -28,6 +28,6 @@ public class DeleteCandidateCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCandidateCommand.MESSAGE_USAGE));
+                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + DeleteCandidateCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteInterviewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteInterviewCommandParserTest.java
@@ -21,6 +21,6 @@ public class DeleteInterviewCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + DeleteInterviewCommand.MESSAGE_USAGE);
+                ParserUtil.MESSAGE_INVALID_INDEX) + DeleteInterviewCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteInterviewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteInterviewCommandParserTest.java
@@ -21,6 +21,6 @@ public class DeleteInterviewCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteInterviewCommand.MESSAGE_USAGE));
+                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + DeleteInterviewCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeletePositionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeletePositionCommandParserTest.java
@@ -21,6 +21,6 @@ class DeletePositionCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + DeletePositionCommand.MESSAGE_USAGE);
+                ParserUtil.MESSAGE_INVALID_INDEX) + DeletePositionCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeletePositionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeletePositionCommandParserTest.java
@@ -21,6 +21,6 @@ class DeletePositionCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeletePositionCommand.MESSAGE_USAGE));
+                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + DeletePositionCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCandidateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCandidateCommandParserTest.java
@@ -30,6 +30,7 @@ import static seedu.address.logic.candidate.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.candidate.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.candidate.CommandTestUtil.VALID_TITLE_ADMIN_ASSISTANT;
 import static seedu.address.logic.candidate.CommandTestUtil.VALID_TITLE_HR_MANAGER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -58,20 +59,28 @@ public class EditCandidateCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + EditCandidateCommand.MESSAGE_USAGE;
+                    ParserUtil.MESSAGE_INVALID_INDEX) + EditCandidateCommand.MESSAGE_USAGE;
+
+    private static final String MESSAGE_INVALID_FORMAT_EMPTY_INDEX =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCandidateCommand.MESSAGE_USAGE);
+
 
     private EditCandidateCommandParser parser = new EditCandidateCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
+        // no index specified, followed by field name=value
+        assertParseFailure(parser, " " + PREFIX_NAME + VALID_NAME_AMY, MESSAGE_INVALID_FORMAT_EMPTY_INDEX);
+
+
+        // no index specified, immediately followed by field value
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
         assertParseFailure(parser, "1", EditCandidateCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT_EMPTY_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCandidateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCandidateCommandParserTest.java
@@ -57,7 +57,8 @@ public class EditCandidateCommandParserTest {
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCandidateCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + EditCandidateCommand.MESSAGE_USAGE;
 
     private EditCandidateCommandParser parser = new EditCandidateCommandParser();
 

--- a/src/test/java/seedu/address/logic/parser/EditInterviewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditInterviewCommandParserTest.java
@@ -41,20 +41,26 @@ public class EditInterviewCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + EditInterviewCommand.MESSAGE_USAGE;
+                    ParserUtil.MESSAGE_INVALID_INDEX) + EditInterviewCommand.MESSAGE_USAGE;
+
+    private static final String MESSAGE_INVALID_FORMAT_EMPTY_INDEX =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditInterviewCommand.MESSAGE_USAGE);
 
     private EditInterviewCommandParser parser = new EditInterviewCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseFailure(parser, VALID_DATE_DESC, MESSAGE_INVALID_FORMAT);
+        // no index specified, followed by field name=value
+        assertParseFailure(parser, VALID_DATE_DESC, MESSAGE_INVALID_FORMAT_EMPTY_INDEX);
+
+        // no index specified, immediately followed by field value
+        assertParseFailure(parser, VALID_DATE, MESSAGE_INVALID_FORMAT);
 
         // no field specified
         assertParseFailure(parser, "1", EditInterviewCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT_EMPTY_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditInterviewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditInterviewCommandParserTest.java
@@ -40,7 +40,8 @@ import seedu.address.testutil.EditInterviewDescriptorBuilder;
 public class EditInterviewCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditInterviewCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + EditInterviewCommand.MESSAGE_USAGE;
 
     private EditInterviewCommandParser parser = new EditInterviewCommandParser();
 

--- a/src/test/java/seedu/address/logic/parser/EditPositionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditPositionCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.position.CommandTestUtil.INVALID_POSITION_STATUS;
@@ -29,20 +30,27 @@ public class EditPositionCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + EditPositionCommand.MESSAGE_USAGE;
+                    ParserUtil.MESSAGE_INVALID_INDEX) + EditPositionCommand.MESSAGE_USAGE;
+
+    private static final String MESSAGE_INVALID_FORMAT_EMPTY_INDEX =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditPositionCommand.MESSAGE_USAGE);
 
     private EditPositionCommandParser parser = new EditPositionCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
+        // no index specified, followed by field name=value
+        assertParseFailure(parser,
+                " " + PREFIX_TITLE + VALID_TITLE_ADMIN_ASSISTANT, MESSAGE_INVALID_FORMAT_EMPTY_INDEX);
+
+        // no index specified, immediately followed by field value
         assertParseFailure(parser, VALID_TITLE_ADMIN_ASSISTANT, MESSAGE_INVALID_FORMAT);
 
         // no field specified
         assertParseFailure(parser, "1", EditPositionCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT_EMPTY_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditPositionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditPositionCommandParserTest.java
@@ -28,7 +28,8 @@ import seedu.address.testutil.EditPositionDescriptorBuilder;
 public class EditPositionCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditPositionCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + EditPositionCommand.MESSAGE_USAGE;
 
     private EditPositionCommandParser parser = new EditPositionCommandParser();
 

--- a/src/test/java/seedu/address/logic/parser/RemarkCandidateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemarkCandidateCommandParserTest.java
@@ -25,7 +25,7 @@ class RemarkCandidateCommandParserTest {
     public void execute_invalidPersonIndex_throwsCommandException() {
         assertParseFailure(parser, model.getFilteredPersonList().size()
                 + VALID_REMARK_BOB, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                RemarkCandidateCommand.MESSAGE_USAGE));
+                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + RemarkCandidateCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/RemarkCandidateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemarkCandidateCommandParserTest.java
@@ -25,7 +25,7 @@ class RemarkCandidateCommandParserTest {
     public void execute_invalidPersonIndex_throwsCommandException() {
         assertParseFailure(parser, model.getFilteredPersonList().size()
                 + VALID_REMARK_BOB, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ParserUtil.MESSAGE_INVALID_INDEX) + "\n" + RemarkCandidateCommand.MESSAGE_USAGE);
+                ParserUtil.MESSAGE_INVALID_INDEX) + RemarkCandidateCommand.MESSAGE_USAGE);
     }
 
     @Test


### PR DESCRIPTION
Fix #251 
When a user now inputs a large invalid integer for fields such as index and duration, a corresponding command failure result message will be shown to notify the user about the mistake.

| command | field | added message |
| - | - | - |
| `edit_x` | INDEX | ..., or bigger than maximum value |
| `delete_x` | INDEX | , or bigger than maximum value |
| `add_i` `edit_i` | duration | ... and less than 1 day (1440 minutes) |