### PR TITLE
Fix unassign warning

### DIFF
--- a/src/test/java/seedu/address/logic/interview/UnassignInterviewCommandTest.java
+++ b/src/test/java/seedu/address/logic/interview/UnassignInterviewCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.interview.CommandTestUtil.assertCommandFailure
 import static seedu.address.logic.interview.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.interview.UnassignInterviewCommand.MESSAGE_ALL_CANDIDATES_REMOVED;
 import static seedu.address.logic.interview.UnassignInterviewCommand.MESSAGE_CANDIDATE_DID_NOT_APPLY;
+import static seedu.address.logic.interview.UnassignInterviewCommand.MESSAGE_CANDIDATE_INDEX_NOT_VALID;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_INTERVIEW;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -118,7 +119,8 @@ public class UnassignInterviewCommandTest {
                 Set.of(invalidCandidateIndex));
 
         assertThrows(CommandException.class,
-                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () -> unassignInterviewCommand.execute(model));
+                String.format(MESSAGE_CANDIDATE_INDEX_NOT_VALID, invalidCandidateIndex.getOneBased()), (
+                        )-> unassignInterviewCommand.execute(model));
     }
 
     @Test


### PR DESCRIPTION
-Separated the checking and the execution phase of the method
-Updated the error message shown so that it includes which candidate-index was invalid
Fix #257 