### PR TITLE
Update assign/unassign to throw error message if c= is left empty

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,8 +8,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_INTERVIEW_DISPLAYED_INDEX = "The interview index provided is invalid";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The candidate index provided is invalid";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d candidates listed!";
     public static final String MESSAGE_POSITIONS_LISTED_OVERVIEW = "%1$d positions listed!";
     public static final String MESSAGE_INVALID_POSITION_DISPLAYED_INDEX = "The position index provided is invalid";
     public static final String MESSAGE_INTERVIEW_LISTED_OVERVIEW = "%1$d interviews listed!";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,6 +37,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_EMPTY_CANDIDATE_INDEXES = "You must enter at least one candidate index";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -411,6 +412,10 @@ public class ParserUtil {
 
         for (String index : tempWithoutDuplicates) {
             characterIndexes.add(parseIndex(index));
+        }
+
+        if (characterIndexes.isEmpty()) {
+            throw new ParseException(MESSAGE_EMPTY_CANDIDATE_INDEXES);
         }
 
         return characterIndexes;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -304,4 +304,9 @@ public class ParserUtilTest {
 
         assertEquals(indexesInIntegers, testAsIntegers);
     }
+
+    @Test
+    public void parseCandidateIndexes_empty_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCandidateIndexes(""));
+    }
 }


### PR DESCRIPTION
- Updated parseCandidateIndexes to throw error if c= is left empty
- Updated messages to show "candidates" instead of "persons"
- Added test case to check if empty candidate indexes throws ParseException