### PR TITLE
Edit p warning and bugfix

### DIFF
--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -27,14 +27,16 @@ public class EditPositionCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the position identified "
             + "by the index number used in the displayed position list. "
             + "Existing values will be overwritten by the input values.\n"
+            + "NOTE: only one field can be edited at one time.\n"
+            + "Valid status values: open, closed.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TITLE + "TITLE] "
             + "[" + PREFIX_POSITION_STATUS + "POSITION STATUS]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_POSITION_STATUS + "close";
+            + PREFIX_POSITION_STATUS + "closed\n";
 
     public static final String MESSAGE_EDIT_POSITION_SUCCESS = "Edited Position: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "Only one field to edit can be provided.";
     public static final String MESSAGE_DUPLICATE_POSITION = "This position already exists in the position list.";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -38,6 +38,7 @@ public class EditPositionCommand extends Command {
     public static final String MESSAGE_EDIT_POSITION_SUCCESS = "Edited Position: %1$s";
     public static final String MESSAGE_NOT_EDITED = "One field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_POSITION = "This position already exists in the position list.";
+    public static final String MESSAGE_BOTH_FIELDS_EDITED = "Only one field can be edited at one time.";
 
     private final Index index;
     private final EditPositionCommand.EditPositionDescriptor editPositionDescriptor;
@@ -68,6 +69,10 @@ public class EditPositionCommand extends Command {
 
         Position positionToEdit = lastShownPositionList.get(index.getZeroBased());
         Position editedPosition = createEditedPosition(positionToEdit, editPositionDescriptor);
+
+        if (editPositionDescriptor.isBothFieldsEdited()) {
+            throw new CommandException(MESSAGE_BOTH_FIELDS_EDITED);
+        }
 
         if (!positionToEdit.isSamePosition(editedPosition) && model.hasPosition(editedPosition)) {
             throw new CommandException(MESSAGE_DUPLICATE_POSITION);
@@ -156,6 +161,13 @@ public class EditPositionCommand extends Command {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(title, status);
+        }
+
+        /**
+         * Returns true if both fields are edited.
+         */
+        public boolean isBothFieldsEdited() {
+            return (CollectionUtil.isAnyNonNull(title) && CollectionUtil.isAnyNonNull(status));
         }
 
         public void setTitle(Title title) {

--- a/src/main/java/seedu/address/logic/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/position/EditPositionCommand.java
@@ -36,7 +36,7 @@ public class EditPositionCommand extends Command {
             + PREFIX_POSITION_STATUS + "closed\n";
 
     public static final String MESSAGE_EDIT_POSITION_SUCCESS = "Edited Position: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "Only one field to edit can be provided.";
+    public static final String MESSAGE_NOT_EDITED = "One field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_POSITION = "This position already exists in the position list.";
 
     private final Index index;

--- a/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/position/EditPositionCommandTest.java
@@ -52,11 +52,27 @@ public class EditPositionCommandTest {
     private Model model = new ModelManager(getTypicalHrManager(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_titleSpecifiedUnfilteredList_success() {
         Position editedPosition =
                 new PositionBuilder().withTitle("Business Analyst").withStatus(VALID_STATUS_OPEN).build();
         EditPositionCommand.EditPositionDescriptor descriptor =
-                new EditPositionDescriptorBuilder(editedPosition).build();
+                new EditPositionDescriptorBuilder().withTitle(editedPosition.getTitle().fullTitle).build();
+        EditPositionCommand editPositionCommand = new EditPositionCommand(INDEX_FIRST_POSITION, descriptor);
+
+        String expectedMessage = String.format(EditPositionCommand.MESSAGE_EDIT_POSITION_SUCCESS, editedPosition);
+
+        Model expectedModel = new ModelManager(new HrManager(model.getHrManager()), new UserPrefs());
+        expectedModel.setPosition(model.getFilteredPositionList().get(0), editedPosition);
+
+        assertEditPositionCommandSuccess(editPositionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_statusSpecifiedUnfilteredList_success() {
+        Position editedPosition =
+                new PositionBuilder().withTitle("Administrative Assistant").withStatus(VALID_STATUS_OPEN).build();
+        EditPositionCommand.EditPositionDescriptor descriptor =
+                new EditPositionDescriptorBuilder().withPositionStatus(editedPosition.getStatus()).build();
         EditPositionCommand editPositionCommand = new EditPositionCommand(INDEX_FIRST_POSITION, descriptor);
 
         String expectedMessage = String.format(EditPositionCommand.MESSAGE_EDIT_POSITION_SUCCESS, editedPosition);
@@ -103,7 +119,7 @@ public class EditPositionCommandTest {
     public void execute_duplicatePositionUnfilteredList_failure() {
         Position firstPosition = model.getFilteredPositionList().get(INDEX_FIRST_POSITION.getZeroBased());
         EditPositionCommand.EditPositionDescriptor descriptor =
-                new EditPositionDescriptorBuilder(firstPosition).build();
+                new EditPositionDescriptorBuilder().withTitle(firstPosition.getTitle().fullTitle).build();
         EditPositionCommand editPositionCommand = new EditPositionCommand(INDEX_SECOND_POSITION, descriptor);
 
         assertCommandFailure(editPositionCommand, model, EditPositionCommand.MESSAGE_DUPLICATE_POSITION);
@@ -116,7 +132,7 @@ public class EditPositionCommandTest {
         // edit position in filtered list into a duplicate in HR Manager
         Position positionInList = model.getHrManager().getPositionList().get(INDEX_SECOND_POSITION.getZeroBased());
         EditPositionCommand editPositionCommand = new EditPositionCommand(INDEX_FIRST_POSITION,
-                new EditPositionDescriptorBuilder(positionInList).build());
+                new EditPositionDescriptorBuilder().withTitle(positionInList.getTitle().fullTitle).build());
 
         assertCommandFailure(editPositionCommand, model, EditPositionCommand.MESSAGE_DUPLICATE_POSITION);
     }
@@ -146,6 +162,15 @@ public class EditPositionCommandTest {
                 new EditPositionDescriptorBuilder().withTitle(VALID_TITLE_BOOKKEEPER).build());
 
         assertCommandFailure(editPositionCommand, model, Messages.MESSAGE_INVALID_POSITION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_bothFieldsEdited_failure() {
+        EditPositionCommand.EditPositionDescriptor descriptor = new EditPositionDescriptorBuilder()
+                .withTitle("Business Analyst")
+                .withPositionStatus(VALID_STATUS_OPEN).build();
+        EditPositionCommand editPositionCommand = new EditPositionCommand(INDEX_FIRST_POSITION, descriptor);
+        assertCommandFailure(editPositionCommand, model, EditPositionCommand.MESSAGE_BOTH_FIELDS_EDITED);
     }
 
     @Test
@@ -181,7 +206,7 @@ public class EditPositionCommandTest {
         Position editedPosition =
                 new PositionBuilder().withTitle("Business Analyst").build();
         EditPositionCommand.EditPositionDescriptor descriptor =
-                new EditPositionDescriptorBuilder(editedPosition).build();
+                new EditPositionDescriptorBuilder().withTitle(editedPosition.getTitle().fullTitle).build();
         EditPositionCommand editPositionCommand = new EditPositionCommand(INDEX_FIRST_POSITION, descriptor);
 
         String expectedMessage = String.format(EditPositionCommand.MESSAGE_EDIT_POSITION_SUCCESS, editedPosition);


### PR DESCRIPTION
- Added warning to users that edit_p only allows editing of one field at a time
- Included valid status for position in message usage
- bugfix: edit_p allowed for editing of both fields
- edited test methods accordingly
