### PR TITLE
Add guard clause to add_i if c= is not given

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInterviewCommandParser.java
@@ -42,12 +42,19 @@ public class AddInterviewCommandParser implements Parser<AddInterviewCommand> {
         }
 
         Position position = ParserUtil.parsePosition(argMultimap.getValue(PREFIX_POSITION).get());
-        Set<Index> indexes = ParserUtil.parseCandidateIndexes(argMultimap.getValue(PREFIX_CANDIDATE_INDEX).orElse(""));
         LocalDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         LocalTime time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
         Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());
         InterviewStatus interviewStatus = ParserUtil.parseInterviewStatus(argMultimap
                 .getValue(PREFIX_INTERVIEW_STATUS).orElse(""));
+
+        Set<Index> indexes;
+        String candidateIndexes = argMultimap.getValue(PREFIX_CANDIDATE_INDEX).orElse("");
+        if (candidateIndexes.equals("")) {
+            indexes = new HashSet<>();
+        } else {
+            indexes = ParserUtil.parseCandidateIndexes(candidateIndexes);
+        }
 
         Interview interview = new Interview(position, new HashSet<>(), date, time, duration, interviewStatus);
 


### PR DESCRIPTION
-parseCandidateIndexes throws error if given ""
    - Add guard clause in add_i to avoid this when `c=` is not given
