### PR TITLE
Update AddCandidateCommand and EditCandidateCommand

### DIFF
--- a/src/main/java/seedu/address/logic/candidate/AddCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/AddCandidateCommand.java
@@ -48,7 +48,8 @@ public class AddCandidateCommand extends Command {
             + PREFIX_TAG + "reviewRequired";
 
     public static final String MESSAGE_SUCCESS = "New candidate added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This candidate already exists in the HR Manager";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Candidate with Email:"
+            + " [ %1$s ] already exists in the HR Manager";
 
     private final Person toAdd;
 
@@ -65,7 +66,7 @@ public class AddCandidateCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON, toAdd.getEmail()));
         }
 
         Set<Position> positions = toAdd.getPositions();

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -61,8 +61,8 @@ public class EditCandidateCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "Candidate with Email:"
             + " [ %1$s ] already exists in the HR Manager";
-    public static final String MESSAGE_ILLEGAL_PERSON_STATUS = "Candidate: [ %1$s ]"
-            + " already have scheduled interview(s)";
+    public static final String MESSAGE_ILLEGAL_PERSON_STATUS = "Unable to change Status of %1$s to APPLIED.\n"
+            + "Candidate %1$s already have scheduled interview(s).";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -62,7 +62,7 @@ public class EditCandidateCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "Candidate with Email:"
             + " [ %1$s ] already exists in the HR Manager";
     public static final String MESSAGE_ILLEGAL_PERSON_STATUS = "Unable to change Status of %1$s to APPLIED.\n"
-            + "Candidate %1$s already have scheduled interview(s).";
+            + "Candidate %1$s already has scheduled interview(s).";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
+++ b/src/main/java/seedu/address/logic/candidate/EditCandidateCommand.java
@@ -59,7 +59,10 @@ public class EditCandidateCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Candidate: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This candidate already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Candidate with Email:"
+            + " [ %1$s ] already exists in the HR Manager";
+    public static final String MESSAGE_ILLEGAL_PERSON_STATUS = "Candidate: [ %1$s ]"
+            + " already have scheduled interview(s)";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -89,7 +92,14 @@ public class EditCandidateCommand extends Command {
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON, editedPerson.getEmail()));
+        }
+
+        if (editPersonDescriptor.getStatus().isPresent()) {
+            Status editedPersonStatus = editPersonDescriptor.getStatus().get();
+            if (personToEdit.getInterviews().size() > 0 && editedPersonStatus == Status.APPLIED) {
+                throw new CommandException(String.format(MESSAGE_ILLEGAL_PERSON_STATUS, personToEdit.getName()));
+            }
         }
 
         Set<Position> newPositions = editedPerson.getPositions();

--- a/src/test/java/seedu/address/logic/candidate/AddCandidateCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/candidate/AddCandidateCommandIntegrationTest.java
@@ -40,7 +40,7 @@ public class AddCandidateCommandIntegrationTest {
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getHrManager().getPersonList().get(0);
         assertCommandFailure(new AddCandidateCommand(personInList), model,
-                AddCandidateCommand.MESSAGE_DUPLICATE_PERSON);
+               String.format(AddCandidateCommand.MESSAGE_DUPLICATE_PERSON, personInList.getEmail()));
     }
 
 }

--- a/src/test/java/seedu/address/logic/candidate/AddCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/AddCandidateCommandTest.java
@@ -52,7 +52,8 @@ public class AddCandidateCommandTest {
         AddCandidateCommand addCandidateCommand = new AddCandidateCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCandidateCommand.MESSAGE_DUPLICATE_PERSON, () ->
+        assertThrows(CommandException.class,
+                String.format(AddCandidateCommand.MESSAGE_DUPLICATE_PERSON, validPerson.getEmail()), () ->
                 addCandidateCommand.execute(modelStub));
     }
 

--- a/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
+++ b/src/test/java/seedu/address/logic/candidate/EditCandidateCommandTest.java
@@ -126,7 +126,8 @@ public class EditCandidateCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCandidateCommand editCandidateCommand = new EditCandidateCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCandidateCommand, model, EditCandidateCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCandidateCommand, model,
+                String.format(EditCandidateCommand.MESSAGE_DUPLICATE_PERSON, firstPerson.getEmail()));
     }
 
     @Test
@@ -138,7 +139,8 @@ public class EditCandidateCommandTest {
         EditCandidateCommand editCandidateCommand = new EditCandidateCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCandidateCommand, model, EditCandidateCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCandidateCommand, model,
+                String.format(EditCandidateCommand.MESSAGE_DUPLICATE_PERSON, personInList.getEmail()));
     }
 
     @Test


### PR DESCRIPTION
* updated message prompt for duplicate persons to show the duplicate email
* updated EditCandidateCommand to not allow status change from scheduled to applied for candidates that already have interviews
* updated corresponding test cases